### PR TITLE
Get input from message element or portType input.

### DIFF
--- a/spec/wasabi/document/authentication_spec.rb
+++ b/spec/wasabi/document/authentication_spec.rb
@@ -15,7 +15,7 @@ describe Wasabi::Document do
 
     its(:operations) do
       should == {
-        :authenticate => { :input => "authenticate", :action => "authenticate" }
+        :authenticate => { :input => "authenticate", :action => "authenticate", :namespace_identifier => "tns" }
       }
     end
 

--- a/spec/wasabi/document/multiple_namespaces_spec.rb
+++ b/spec/wasabi/document/multiple_namespaces_spec.rb
@@ -14,7 +14,7 @@ describe Wasabi::Document do
     it { should have(1).operations }
 
     its(:operations) do
-      should == { :save => { :input => "Save", :action => "http://example.com/actions.Save" } }
+      should == { :save => { :input => "Save", :action => "http://example.com/actions.Save", :namespace_identifier => "actions" } }
     end
 
     its(:type_namespaces) do

--- a/spec/wasabi/document/namespaced_actions_spec.rb
+++ b/spec/wasabi/document/namespaced_actions_spec.rb
@@ -15,9 +15,9 @@ describe Wasabi::Document do
 
     its(:operations) do
       should include(
-        { :delete_client => { :input => "DeleteClient", :action => "http://api.example.com/api/Client.Delete" } },
-        { :get_clients   => { :input => "GetClients", :action => "http://api.example.com/api/User.GetClients" } },
-        { :get_api_key   => { :input => "GetApiKey", :action => "http://api.example.com/api/User.GetApiKey" } }
+        { :delete_client => { :input => "Client.Delete", :action => "http://api.example.com/api/Client.Delete", :namespace_identifier => "tns" } },
+        { :get_clients   => { :input => "User.GetClients", :action => "http://api.example.com/api/User.GetClients", :namespace_identifier => "tns" } },
+        { :get_api_key   => { :input => "User.GetApiKey", :action => "http://api.example.com/api/User.GetApiKey", :namespace_identifier => "tns" } }
       )
     end
 

--- a/spec/wasabi/document/no_namespace_spec.rb
+++ b/spec/wasabi/document/no_namespace_spec.rb
@@ -15,9 +15,9 @@ describe Wasabi::Document do
 
     its(:operations) do
       should include(
-        { :get_user_login_by_id => { :input => "GetUserLoginById", :action => "/api/api/GetUserLoginById" } },
-        { :get_all_contacts => { :input => "GetAllContacts", :action => "/api/api/GetAllContacts" } },
-        { :search_user => { :input => "SearchUser", :action => "/api/api/SearchUser" } }
+        { :get_user_login_by_id => { :input => "GetUserLoginById", :action => "/api/api/GetUserLoginById", :namespace_identifier => "typens" } },
+        { :get_all_contacts => { :input => "GetAllContacts", :action => "/api/api/GetAllContacts", :namespace_identifier => "typens" } },
+        { :search_user => { :input => "SearchUser", :action => "/api/api/SearchUser", :namespace_identifier => "typens" } }
       )
     end
 


### PR DESCRIPTION
This PR will enable wasabi to automatically include the proper input message by inspecting the WSDL document.  Sometimes, the `operation` name in the `binding` isn't the exact input message that is expected.  The real input message is usually specified in a `message` element.  This is best shown by example:

``` xml
<?xml version='1.0' encoding='UTF-8'?>
<wsdl:definitions 
    name="AuthenticationWebServiceImplService"
    targetNamespace="http://v1_0.ws.auth.order.example.com/"
    xmlns:ns1="http://cxf.apache.org/bindings/xformat"
    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
    xmlns:tns="http://v1_0.ws.auth.order.example.com/"
    xmlns:tns1="http://v1_0.ws.auth.order.example.com/request"
    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
    xmlns:xsd="http://www.w3.org/2001/XMLSchema">

    <wsdl:types>
        <xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://v1_0.ws.auth.order.example.com/" xmlns:tns="http://v1_0.ws.auth.order.example.com/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
            ...
        </xs:schema>
    </wsdl:types>
    <wsdl:message name="authenticate">
        <wsdl:part element="tns1:AuthenticateUser" name="parameters" />
    </wsdl:message>
    <wsdl:message name="authenticateResponse">
        <wsdl:part element="tns:AuthenticateResponse" name="parameters" />
    </wsdl:message>
    <wsdl:portType name="AuthenticationWebService">
        <wsdl:operation name="authenticate">
            <wsdl:input message="tns:authenticate" name="authenticate" />
            <wsdl:output message="tns:authenticateResponse" name="authenticateResponse" />
        </wsdl:operation>
    </wsdl:portType>
    <wsdl:binding name="AuthenticationWebServiceImplServiceSoapBinding" type="tns:AuthenticationWebService">
        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
        <wsdl:operation name="authenticate">
            <soap:operation soapAction="" style="document" />
            <wsdl:input name="authenticate">
                <soap:body use="literal" />
            </wsdl:input>
            <wsdl:output name="authenticateResponse">
                <soap:body use="literal" />
            </wsdl:output>
        </wsdl:operation>
    </wsdl:binding>
    <wsdl:service name="AuthenticationWebServiceImplService">
        <wsdl:port binding="tns:AuthenticationWebServiceImplServiceSoapBinding" name="AuthenticationWebServiceImplPort">
            <soap:address location="http://example.com/validation/1.0/AuthenticationService" />
        </wsdl:port>
    </wsdl:service>
</wsdl:definitions>
```

In this example, the `operation`'s `input` name is `authenticate`, and the `message` attribute is `tns:authenticate`.  Neither of these are the proper, expected input message of `AuthenticateUser`.  For this, we need to walk up the `portType`, then to the matching `message` to get the actual input message of `AuthenticateUser`.  See Savon PR [#277](https://github.com/rubiii/savon/pull/277) to get the full picture on how this all works together, and enables you to pass a single symbol into the `Savon::Client#request` method and get automatic namespace mapping, as well as the proper operation name -> input message mapping.
