### PR TITLE
Fix for issue #21

### DIFF
--- a/lib/wasabi/resolver.rb
+++ b/lib/wasabi/resolver.rb
@@ -7,7 +7,13 @@ module Wasabi
   # Resolves local and remote WSDL documents.
   class Resolver
 
-    class HTTPError < StandardError; end
+    class HTTPError < StandardError
+      def initialize(message, response=nil)
+        super(message)
+        @response = response
+      end
+      attr_reader :response
+    end
 
     URL = /^http[s]?:/
     XML = /^</
@@ -35,7 +41,8 @@ module Wasabi
       request.url = document
       response = HTTPI.get(request)
 
-      raise HTTPError, response if response.error?
+      raise HTTPError.new("Error: #{response.code}", response) if response.error?
+
       response.body
     end
 

--- a/spec/wasabi/resolver_spec.rb
+++ b/spec/wasabi/resolver_spec.rb
@@ -18,6 +18,23 @@ describe Wasabi::Resolver do
       xml = Wasabi::Resolver.new("<xml/>").resolve
       xml.should == "<xml/>"
     end
+
+    it "raises HTTPError when #load_from_remote gets a response error" do
+      code = 404
+      headers = {
+        "content-type" => "text/html"
+      }
+      body = "<html><head><title>404 Not Found</title></head><body>Oops!</body></html>"
+      failed_response = HTTPI::Response.new(code, headers, body)
+      HTTPI.stub(:get => failed_response)
+      lambda do
+        Wasabi::Resolver.new("http://example.com?wsdl").resolve
+      end.should raise_error { |ex|
+        ex.should be_a(Wasabi::Resolver::HTTPError)
+        ex.message.should == "Error: #{code}"
+        ex.response.should == failed_response
+      }
+    end
   end
 
 end


### PR DESCRIPTION
When the resolver gets an erroneous response (such as a 404), raise
an HTTPError with:
- `message` set to "Error: 404" (or whatever the code is)
- `response` set to the original response object
