### PR TITLE
Fix issue when searching for 1.2 SOAP operations

### DIFF
--- a/lib/wasabi/operation_builder.rb
+++ b/lib/wasabi/operation_builder.rb
@@ -34,11 +34,9 @@ class Wasabi
 
     def find_soap_service
       @documents.services.each do |name, service|
-        soap_1_1_port = service.soap_1_1_port
-        return [service, Wasabi::SOAP_1_1] if soap_1_1_port
+        return [service, Wasabi::SOAP_1_1] if service.soap_1_1_port
 
-        service.soap_1_2_port
-        return [service, Wasabi::SOAP_1_2] if soap_1_2_port
+        return [service, Wasabi::SOAP_1_2] if service.soap_1_2_port
       end
 
       raise 'Unable to find a SOAP service'


### PR DESCRIPTION
This code was raising exceptions about not having a variable declared in case of 1.2 operations.

I've wanted to add at least an integration test for this fix, but didn't find any WSDL to break the actual code. And unfortunately, the WSDL used to discover the issue was a proprietary service from a current client, so I'm not allowed to share :cry: 
