### PR TITLE
Fixed the lines that caused warnings when running in debug mode

### DIFF
--- a/lib/wasabi/core_ext/string.rb
+++ b/lib/wasabi/core_ext/string.rb
@@ -5,9 +5,9 @@ module Wasabi
       # Returns the String in snakecase.
       def snakecase
         str = dup
-        str.gsub! /::/, '/'
-        str.gsub! /([A-Z]+)([A-Z][a-z])/, '\1_\2'
-        str.gsub! /([a-z\d])([A-Z])/, '\1_\2'
+        str.gsub!(/::/, '/')
+        str.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+        str.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
         str.tr! ".", "_"
         str.tr! "-", "_"
         str.downcase!

--- a/lib/wasabi/document.rb
+++ b/lib/wasabi/document.rb
@@ -25,7 +25,9 @@ module Wasabi
       self.document = document
     end
 
-    attr_accessor :document, :request, :xml
+    attr_accessor :document, :request
+
+    attr_writer :xml
 
     alias_method :document?, :document
 


### PR DESCRIPTION
Removes following warnings

lib/wasabi/core_ext/string.rb:8: warning: ambiguous first argument; put parentheses or even spaces
lib/wasabi/core_ext/string.rb:9: warning: ambiguous first argument; put parentheses or even spaces
lib/wasabi/core_ext/string.rb:10: warning: ambiguous first argument; put parentheses or even spaces
lib/wasabi/document.rb:138: warning: method redefined; discarding old xml
