### PR TITLE
Allow support for newer versions of Nokogiri when using Ruby > 1.8

### DIFF
--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -15,7 +15,13 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "httpi",    "~> 2.0"
-  s.add_dependency "nokogiri", ">= 1.4.0", "< 1.6"
+
+  if RUBY_VERSION[0,3] == "1.8"
+    # nokogiri 1.6 dropped support for ruby 1.8
+    s.add_dependency "nokogiri", ">= 1.4.0", "< 1.6"
+  else
+    s.add_dependency "nokogiri", ">= 1.4.0"
+  end
 
   s.add_development_dependency "rake",  "~> 0.9"
   s.add_development_dependency "rspec", "~> 2.10"


### PR DESCRIPTION
This same approach is used in the Savon gemspec (version2 branch), however due to the Wasabi dependency we were still not able to update to Nokogiri 1.6.
