### PR TITLE
Pin mime-types at < 2.0.0 on rubies < 1.9

### DIFF
--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -17,6 +17,10 @@ Gem::Specification.new do |s|
   s.add_dependency "httpi",    "~> 2.0"
   s.add_dependency "nokogiri", ">= 1.4.0", "< 1.6"
 
+  if RUBY_VERSION < "1.9"
+    s.add_dependency "mime-types", "< 2.0.0"
+  end
+
   s.add_development_dependency "rake",  "~> 0.9"
   s.add_development_dependency "rspec", "~> 2.10"
 


### PR DESCRIPTION
Thinking that removing support for 1.8 since it's been EOL'd would
be the sane choice here, but I am not entirely certain that I want
to make that choice all up at front.

The easiest thing to do, from a community perspective would be to
remove support for 1.8 in Savon 3 and to bump Wasabi, Nori, etc
at the same time.
