### PR TITLE
fixed problem with port_message part in case there is no namespace set

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -263,7 +263,11 @@ module Wasabi
 
         if port_message_part
           if (port_message_part_element = port_message_part.attribute("element"))
-            message_ns_id, message_type = port_message_part_element.to_s.split(':')
+            if port_message_part_element.to_s.include? ':'
+              message_ns_id, message_type = port_message_part_element.to_s.split(':')
+            else
+              message_type = port_message_part_element.to_s
+            end
           end
         end
 


### PR DESCRIPTION
Some WSDL's don't have a namespace set (separated by a colon) in the operation names and hence this needs to be taken care if in order to successfully determine the correct message name for sending out the SOAP request.
