### PR TITLE
process xsd inidcators for nested complex types

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -183,12 +183,7 @@ module Wasabi
         element_name = inner.attribute('name').to_s
         @types[name][element_name] = { :type => inner.attribute('type').to_s }
 
-        [ :nillable, :minOccurs, :maxOccurs ].each do |attr|
-          if v = inner.attribute(attr.to_s)
-            @types[name][element_name][attr] = v.to_s
-          end
-        end
-
+        parse_indicators(namespace,element_name,inner)
         @types[name][:order!] << element_name
       end
 
@@ -196,6 +191,7 @@ module Wasabi
         element_name = inner_element.attribute('name').to_s
         @types[name][element_name] = { :type => inner_element.attribute('type').to_s }
 
+        parse_indicators(namespace,element_name,inner_element)
         @types[name][:order!] << element_name
       end
 
@@ -313,6 +309,18 @@ module Wasabi
       end
 
       @sections = sections
+    end
+
+    private
+
+    # parse XSD indicators
+    def parse_indicators(name,element_name,inner_xml)
+
+        [ :nillable, :minOccurs, :maxOccurs ].each do |attr|
+          if v = inner_xml.attribute(attr.to_s)
+            @types[name][element_name][attr] = v.to_s
+          end
+        end
     end
   end
 end


### PR DESCRIPTION
parse XSD indicators (nillable, minOccurs, maxOccurs) for complex types even they are nested 
