### PR TITLE
Failing spec for issue #562

### DIFF
--- a/spec/fixtures/savon562.wsdl
+++ b/spec/fixtures/savon562.wsdl
@@ -1,0 +1,13882 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions targetNamespace="http://www.lagan.com/wsdl/FLService" xmlns:fls="http://www.lagan.com/wsdl/FLService" xmlns:flt="http://www.lagan.com/wsdl/FLTypes" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <!--*********************************************************************************-->
+
+    <!--  WSDL TYPES  -->
+
+    <!--*********************************************************************************-->
+
+     <wsdl:types>
+
+          <xs:schema targetNamespace="http://www.lagan.com/wsdl/FLTypes" xmlns="http://www.lagan.com/wsdl/FLTypes" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+
+            <!--  LinkCases -->
+
+               <xs:element name="FLLinkCasesParams">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="CaseID" type="xs:long"/>
+
+                              <xs:element name="TargetCaseID" type="xs:long"/>
+
+                              <xs:element name="LinkType" type="xs:int"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FLLinkCasesParamsResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FLUnLinkCasesParams">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="1" ref="FLLinkCasesParams"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FLUnLinkCasesParamsResponse" type="FWTResponseStatus"/>
+
+
+            <!--*************************************************************************-->
+
+            <!--  COMMON TYPES  -->
+
+            <!--*************************************************************************-->
+
+			   <xs:simpleType name="FWTResponseStatus">
+
+				    <xs:restriction base="xs:int"/>
+
+			   </xs:simpleType>
+
+
+               <xs:simpleType name="FWTEventCode">
+
+                    <xs:restriction base="xs:int"/>
+
+               </xs:simpleType>
+
+
+               <xs:simpleType name="FWTEventInformation">
+
+                    <xs:restriction base="xs:string"/>
+
+               </xs:simpleType>
+
+
+               <xs:complexType name="FWTEventInformationList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="EventInformation" type="FWTEventInformation"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+               <xs:element name="FWTException">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="ErrorMessage">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="4000"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element name="ErrorCode" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="AdditionalInfo">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="1000"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTUser">
+
+                    <xs:sequence>
+
+                         <xs:annotation>
+
+                              <xs:documentation>
+
+                            Specify UserID or UserName or both
+                              </xs:documentation>
+
+                         </xs:annotation>
+
+                         <xs:element minOccurs="0" name="UserID">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="UserName">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="50"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTAuditDetails">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        For the create/update individual/organisation
+                        operations, if any element contains an
+                        FWTAuditDetails element, the FWTAuditDetails
+                        element should be left empty.
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="Created" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="CreatedBy" type="FWTUser"/>
+
+                         <xs:element minOccurs="0" name="LastModified" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="LastModifiedBy" type="FWTUser"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTNote">
+
+                    <xs:sequence>
+
+                         <xs:element name="NoteID" type="xs:long"/>
+
+                         <xs:element name="Text">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="4000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Created" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="CreatedBy" type="FWTUser"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTDocument">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="1" name="Document">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="1" name="DocumentType" type="xs:int"/>
+
+                              <xs:element minOccurs="1" name="DocumentName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTNoteDetailAttachmentList">
+
+                        <xs:sequence>
+
+                             <xs:element maxOccurs="unbounded" minOccurs="0" name="NoteAttachmentList" type="FWTNoteDetailAttachment"/>
+
+                        </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTNoteDetail">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="NoteId" type="xs:long"/>
+
+                         <xs:element minOccurs="0" name="Created" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="CreatedBy" type="FWTUser"/>
+
+                         <xs:element minOccurs="0" name="Text">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="NoteAttachments" type="FWTNoteDetailAttachmentList"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTNoteDetailAttachment">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="1" minOccurs="1" name="AttachmentName" type="xs:string"/>
+
+                         <xs:element maxOccurs="1" minOccurs="1" name="AttachmentIdentifier" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="AttachmentType" type="xs:int"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTNoteToParent">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="1" name="ParentId" type="xs:long"/>
+
+                         <xs:element minOccurs="1" name="ParentType" type="xs:int">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                0: for case
+                                1: for interaction
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="NoteDetails" type="FWTNoteDetail"/>
+
+                         <xs:element minOccurs="0" name="EventCode" type="FWTEventCode"/>
+
+                         <xs:element minOccurs="0" name="EventInformationList" type="FWTEventInformationList"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+
+               <xs:element name="FWTNoteToParentRef" type="FWTNoteToParent"/>
+
+			   <xs:element name="FWTNoteToParentRefResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FWTNoteToParentGetRef" type="FWTNoteToParent"/>
+
+               <xs:element name="FWTNoteDetailRef" type="FWTNoteDetail"/>
+
+               <xs:element name="FWTNoteDetailDeleteRef" type="FWTNoteDetail"/>
+
+               <xs:element name="FWTNoteDetailUpdateRef" type="FWTNoteDetail"/>
+
+               <xs:element name="FWTNoteDetailGetRef" type="FWTNoteDetail"/>
+
+               <xs:element name="FWTNoteDetailList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="NoteDetails" type="FWTNoteDetail"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+
+               <xs:simpleType name="FWTDocumentIdRef">
+
+                        <xs:restriction base="xs:string">
+
+                        </xs:restriction>
+
+               </xs:simpleType>
+
+               <xs:element name="FWTDocumentRef" type="FWTDocumentIdRef"/>
+
+               <xs:element name="FWTDocumentGetRef" type="FWTDocumentIdRef"/>
+
+               <xs:element name="FWTDocumentRemoveRef" type="FWTDocumentIdRef"/>
+
+               <xs:complexType name="FWTNoteList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Note" type="FWTNote"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+               <xs:complexType name="FWTKeyValue">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="1" minOccurs="0" name="Key">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                The name of the property this value
+                                denotes
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="30"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:choice maxOccurs="1" minOccurs="0">
+
+                              <xs:element name="NumberValue" nillable="true" type="xs:long"/>
+
+                              <xs:element name="StringValue" nillable="true" type="xs:string"/>
+
+                              <xs:element name="DateValue" nillable="true" type="xs:date"/>
+
+                              <xs:element name="BlockedValue" nillable="true" type="xs:string"/>
+
+                              <xs:element name="DateTimeValue" nillable="true" type="xs:dateTime"/>
+
+                         </xs:choice>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+               <xs:complexType name="FWTExtensionChild">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="1" name="RecordID" type="xs:long"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Value" type="FWTKeyValue"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+               <xs:complexType name="FWTExtensionChildSet">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="1" minOccurs="1" name="Name">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="30"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Child" type="FWTExtensionChild"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+               <xs:complexType name="FWTExtensionObject">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="1" name="ObjectID" type="xs:long"/>
+
+                         <xs:element minOccurs="0" name="BriefDetails" type="FWTObjectBriefDetails"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Value" type="FWTKeyValue"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ChildSet" type="FWTExtensionChildSet"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+               <xs:complexType name="FWTExtensionParty">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="1" name="ObjectID" type="xs:long"/>
+
+                         <xs:element minOccurs="0" name="BriefDetails" type="FWTObjectBriefDetails"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPostals" type="FWTContactPostal"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPhones" type="FWTContactPhone"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactEmails" type="FWTContactEmail"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Value" type="FWTKeyValue"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ChildSet" type="FWTExtensionChildSet"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+            <!--*************************************************************************-->
+
+            <!--  CASE TYPES  -->
+
+            <!--*************************************************************************-->
+
+               <xs:simpleType name="FWTCaseReference">
+
+                    <xs:restriction base="xs:string">
+
+                         <xs:maxLength value="50"/>
+
+                    </xs:restriction>
+
+               </xs:simpleType>
+
+               <xs:element name="CaseReference" type="FWTCaseReference"/>
+
+               <xs:element name="NewCaseReference" type="FWTCaseReference"/>
+
+               <xs:complexType name="FWTCaseReferenceList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" ref="CaseReference"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FLAddCaseList" type="FWTCaseReferenceList"/>
+
+			   <xs:element name="FLAddCaseListResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FLRemoveCaseList" type="FWTCaseReferenceList"/>
+
+			   <xs:element name="FLRemoveCaseListResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FLDeleteCaseList" type="FWTCaseReferenceList"/>
+
+			   <xs:element name="FLDeleteCaseListResponse" type="FWTResponseStatus"/>
+
+               <xs:complexType name="FWTCaseClassification">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" name="Classifier">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="50"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCaseFormField">
+
+                    <xs:sequence>
+
+                         <xs:element name="Value" type="xs:string"/>
+
+                         <xs:element name="Key">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Label">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Type" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                int, string, boolean, date, blocked
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Format" type="xs:string"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCaseForm">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" name="FormField" type="FWTCaseFormField"/>
+
+                         <xs:element minOccurs="0" name="FormName">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="FormKey">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:simpleType name="FWTCaseQueue">
+
+                    <xs:restriction base="xs:string">
+
+                         <xs:maxLength value="100"/>
+
+                    </xs:restriction>
+
+               </xs:simpleType>
+
+               <xs:simpleType name="FWTUserID">
+
+                    <xs:restriction base="xs:string">
+
+                         <xs:maxLength value="100"/>
+
+                    </xs:restriction>
+
+               </xs:simpleType>
+
+               <xs:element name="TaskID" type="xs:int"/>
+
+               <xs:complexType name="FWTCaseTask">
+
+                    <xs:sequence>
+
+                         <xs:element ref="TaskID"/>
+
+                         <xs:element name="Name">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="64"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Description">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="2000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="Type">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="64"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="Priority">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="64"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="DueDate" type="xs:dateTime"/>
+
+                         <xs:element name="Status" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                incomplete, complete
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Completed" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="Notes" type="FWTNoteList"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCaseTaskList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="CaseTask" type="FWTCaseTask"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTCaseTaskNew">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="CaseReference"/>
+
+                              <xs:element minOccurs="0" name="TaskDefinitionID" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="ManualTask">
+
+                                   <xs:complexType>
+
+                                        <xs:sequence>
+
+                                             <xs:element name="Name">
+
+                                                  <xs:simpleType>
+
+                                                       <xs:restriction base="xs:string">
+
+                                                            <xs:maxLength value="64"/>
+
+                                                       </xs:restriction>
+
+                                                  </xs:simpleType>
+
+                                             </xs:element>
+
+                                             <xs:element minOccurs="0" name="Description">
+
+                                                  <xs:simpleType>
+
+                                                       <xs:restriction base="xs:string">
+
+                                                            <xs:maxLength value="2000"/>
+
+                                                       </xs:restriction>
+
+                                                  </xs:simpleType>
+
+                                             </xs:element>
+
+                                             <xs:element minOccurs="0" name="Type" type="xs:string"/>
+
+                                             <xs:element minOccurs="0" name="Priority" type="xs:string"/>
+
+                                             <xs:choice>
+
+                                                  <xs:element name="DueDate" type="xs:dateTime"/>
+
+                                                  <xs:element name="Duration">
+
+                                                       <xs:complexType>
+
+                                                            <xs:sequence>
+
+                                                                 <xs:element name="TimeUnit">
+
+                                                                      <xs:annotation>
+
+                                                                           <xs:documentation>
+
+                                                                minute,
+                                                                hour,
+                                                                day,
+                                                                week
+                                                                           </xs:documentation>
+
+                                                                      </xs:annotation>
+
+                                                                      <xs:simpleType>
+
+                                                                           <xs:restriction base="xs:string"/>
+
+                                                                      </xs:simpleType>
+
+                                                                 </xs:element>
+
+                                                                 <xs:element name="TimeAmount" type="xs:int"/>
+
+                                                                 <xs:element name="WorkingTime" type="xs:boolean"/>
+
+                                                                 <xs:element maxOccurs="1" minOccurs="0" name="CalendarKey" type="xs:string"/>
+
+                                                            </xs:sequence>
+
+                                                       </xs:complexType>
+
+                                                  </xs:element>
+
+                                             </xs:choice>
+
+                                             <xs:element maxOccurs="unbounded" minOccurs="0" name="EscalationRuleName">
+
+                                                  <xs:simpleType>
+
+                                                       <xs:restriction base="xs:string">
+
+                                                            <xs:maxLength value="32"/>
+
+                                                       </xs:restriction>
+
+                                                  </xs:simpleType>
+
+                                             </xs:element>
+
+                                        </xs:sequence>
+
+                                   </xs:complexType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCaseTaskUpdate">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="TaskID"/>
+
+                              <xs:element name="Status" type="xs:string">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    incomplete, complete
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Completed" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="DueDate" type="xs:dateTime"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTCaseTaskUpdateResponse" type="FWTResponseStatus"/>
+
+               <xs:complexType name="FWTCaseEvent">
+
+                    <xs:sequence>
+
+                         <xs:element name="EventTitle">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="30"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="Created" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="HandledBy" type="FWTUser"/>
+
+                         <xs:element minOccurs="0" name="AdditionalInfo">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="2000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="CaseQueue" type="FWTCaseQueue"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCaseEventList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="CaseEvent" type="FWTCaseEvent"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTCaseEventNew">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="CaseReference"/>
+
+                              <xs:element name="EventTitle">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="30"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="AdditionalInfo">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="2000"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="ProxyUserID">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="ProxyUserName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTCaseEventNewResponse" type="FWTResponseStatus"/>
+
+               <xs:complexType name="FWTCaseEform">
+
+                    <xs:sequence>
+
+                         <xs:element name="Name">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="URL">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="2000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="Created" type="xs:dateTime"/>
+
+                         <xs:element name="LastModified" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="ContentRepositoryVersion" type="xs:string"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCaseEformList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="CaseEform" type="FWTCaseEform"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTCaseEformNew">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="CaseReference"/>
+
+                              <xs:element name="EformName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="URL">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="2000"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTCaseEformNewResponse" type="FWTResponseStatus"/>
+
+               <xs:complexType name="FWTCaseWorkflow">
+
+                    <xs:sequence>
+
+                         <xs:element name="FlowName">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="30"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="unbounded" name="Queue" type="FWTCaseQueue"/>
+
+                         <xs:element name="ExceptionQueue" type="FWTCaseQueue"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCaseWorkflowInstance">
+
+                    <xs:sequence>
+
+                         <xs:element name="Workflow" type="FWTCaseWorkflow"/>
+
+                         <xs:element name="CurrentStep" type="xs:int"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCaseBriefDetails">
+
+                    <xs:sequence>
+
+                         <xs:element ref="CaseReference"/>
+
+                         <xs:element name="Status" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                open, closed
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element name="Opened" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="EndDate" type="xs:dateTime"/>
+
+                         <xs:element name="RaisedByUser" type="FWTUser"/>
+
+                         <xs:element name="Classification" type="FWTCaseClassification"/>
+
+                         <xs:element minOccurs="0" name="Title">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="AssociatedObject" type="FWTObjectBriefDetails"/>
+
+                         <xs:element name="Category" type="xs:int"/>
+
+                         <xs:element minOccurs="0" name="CategoryDescription" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="CategoryNameKey" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="CategoryNameValue" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="XCoord" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="YCoord" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="LastModifiedDate" type="xs:dateTime"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTCaseBriefDetailsList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="CaseBriefDetails" type="FWTCaseBriefDetails"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTCaseCoreDetails">
+
+                    <xs:sequence>
+
+                         <xs:element ref="CaseReference"/>
+
+                         <xs:element name="Status" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+open, closed       </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element name="Opened" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="Closed" type="xs:dateTime"/>
+
+                         <xs:element name="RaisedByUser" type="FWTUser"/>
+
+                         <xs:element name="Classification" type="FWTCaseClassification"/>
+
+                         <xs:element minOccurs="0" name="Title">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="AssociatedObject" type="FWTObjectBriefDetails"/>
+
+                         <xs:element name="Category" type="xs:int"/>
+
+                         <xs:element minOccurs="0" name="CategoryDescription" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="CategoryNameKey" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="CategoryNameValue" type="xs:string"/>
+
+                         <xs:element name="Priority" type="xs:int"/>
+
+                         <xs:element name="Severity" type="xs:int"/>
+
+                         <xs:element name="WorkflowCase" type="xs:boolean"/>
+
+                         <xs:element name="Internal" type="xs:boolean"/>
+
+                         <xs:element minOccurs="0" name="Description">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="4000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Queue" type="FWTCaseQueue"/>
+
+                         <xs:element minOccurs="0" name="DueDate" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="CurrentHandler" type="FWTUser"/>
+
+                         <xs:element minOccurs="0" name="XCoord" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="YCoord" type="xs:string"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTCaseCoreDetailsList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="CaseCoreDetails" type="FWTCaseCoreDetails"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCaseFullDetailsRequest">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="CaseReference"/>
+
+                              <xs:element maxOccurs="unbounded" name="Option">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Values: all, core, eforms-r,
+                                    eforms-rw, events, form, fullform,
+                                    notes, tasks, workflow,
+                                    interactions, eform-data, linkcases
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="20"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTLaganCaseSearchParams">
+
+            	    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="query" type="xs:string"/>
+
+                              <xs:element name="startIndex" type="xs:int"/>
+
+                              <xs:element name="numberOfRecords" type="xs:int"/>
+
+                              <xs:element name="sortField" type="xs:string"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTSearchCaseDetailsRequest">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="FWTLaganCaseSearchParams"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTSearchTaskDetailsRequest">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="FWTLaganCaseSearchParams"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTSearchInteractionDetailsRequest">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="FWTLaganCaseSearchParams"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTSearchCaseDetailsResult">
+
+            	    <xs:complexType>
+
+            		     <xs:sequence>
+
+                              <xs:element ref="FWTCaseCoreDetailsList"/>
+
+                         </xs:sequence>
+
+            	    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTSearchTaskDetailsResult">
+
+            	    <xs:complexType>
+
+            		     <xs:sequence>
+
+            			      <xs:element maxOccurs="unbounded" minOccurs="0" ref="FWTCaseRelatedTask"/>
+
+                         </xs:sequence>
+
+            	    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCaseRelatedTask">
+
+            	    <xs:complexType>
+
+            		     <xs:sequence>
+
+            			      <xs:element name="CaseTask" type="FWTCaseTask"/>
+
+                              <xs:element name="CaseId" type="xs:string"/>
+
+            		     </xs:sequence>
+
+            	    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTSearchInteractionDetailsResult">
+
+            	    <xs:complexType>
+
+            		     <xs:sequence>
+
+                        <!-- <xs:element name="CaseInteractionList" type="FWTInteractionDetailsList" minOccurs="0" maxOccurs="1"/> -->
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" ref="FWTCaseRelatedInteraction"/>
+
+                         </xs:sequence>
+
+            	    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCaseRelatedInteraction">
+
+            	    <xs:complexType>
+
+            		     <xs:sequence>
+
+            			      <xs:element name="InteractionDetails" type="FWTInteractionDetails"/>
+
+                              <xs:element name="CaseId" type="xs:string"/>
+
+            		     </xs:sequence>
+
+            	    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCaseFullDetails">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="0" name="CoreDetails" type="FWTCaseCoreDetails"/>
+
+                              <xs:element minOccurs="0" name="Form" type="FWTCaseForm"/>
+
+                              <xs:element minOccurs="0" name="Events" type="FWTCaseEventList"/>
+
+                              <xs:element minOccurs="0" name="Tasks" type="FWTCaseTaskList"/>
+
+                              <xs:element minOccurs="0" name="Workflow" type="FWTCaseWorkflowInstance"/>
+
+                              <xs:element minOccurs="0" name="Notes" type="FWTNoteList"/>
+
+                              <xs:element minOccurs="0" name="Eforms" type="FWTCaseEformList"/>
+
+                              <xs:element minOccurs="0" name="Interactions" type="FWTInteractionDetailsList"/>
+
+                              <xs:element minOccurs="0" name="EformData" type="FWTCaseEformDataList"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="LinkCases" type="FWTLinkedCase">
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCaseFullDetailsList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" ref="FWTCaseFullDetails"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCaseCreate">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="ClassificationEventCode" type="FWTEventCode"/>
+
+                              <xs:element minOccurs="0" name="Priority" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="Title">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Description">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="4000"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Queue" type="FWTCaseQueue"/>
+
+                              <xs:element minOccurs="0" name="DueDate" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="AssociatedObject" type="FWTObjectBriefDetails"/>
+
+                              <xs:element minOccurs="0" name="Form" type="FWTCaseForm"/>
+
+                              <xs:element minOccurs="0" name="Internal" type="xs:boolean"/>
+
+                              <xs:element minOccurs="0" ref="InteractionID"/>
+
+                              <xs:element minOccurs="0" name="Parent" type="FWTDomainObjectID"/>
+
+                              <xs:element minOccurs="0" name="XCoord" type="xs:string"/>
+
+                              <xs:element minOccurs="0" name="YCoord" type="xs:string"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCaseSearch">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="0" ref="CaseReference"/>
+
+                              <xs:element minOccurs="0" name="Status" type="xs:string">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    open, closed, all (If no value is
+                                    supplied the default is all)
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="ClassificationEventCode" type="FWTEventCode"/>
+
+                              <xs:element minOccurs="0" name="Title">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="200"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Queue" type="FWTCaseQueue"/>
+
+                              <xs:element minOccurs="0" name="AssociatedObjectDescription">
+
+                                   <xs:simpleType>
+
+                                            <xs:restriction base="xs:string">
+
+                                                 <xs:maxLength value="255"/>
+
+                                            </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="AssociatedObjectId" type="FWTObjectID"/>
+
+                              <xs:element minOccurs="0" name="RaisedByUser" type="FWTUser">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    User ID
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="CurrentHandler" type="FWTUser">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    User ID
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="CreatedAfter" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="CreatedBefore" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="PriorityMinimum" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="PriorityMaximum" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="ResultsLimit" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="SeverityMinimum" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="SeverityMaximum" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="CategoryNameKey">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                     NAMEKEY field used in the LGNCC_CASECATEGORYDEFINITION table
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="LastModifiedDateFrom" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="LastModifiedDateTo" type="xs:dateTime"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTCaseActionReason">
+
+                    <xs:sequence>
+
+                         <xs:element name="Title">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="30"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Description">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="2000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTCaseClose">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" ref="CaseReference"/>
+
+                              <xs:element name="Reason" type="FWTCaseActionReason"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTCaseCloseResponse" type="FWTResponseStatus"/>
+
+               <xs:complexType name="FWTCaseNoteUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="NoteID" type="xs:long"/>
+
+                         <xs:element name="NoteText">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="4000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTBPMCaseUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="BPMReference">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="50"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="BPMUpdateType" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                add, remove
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTCaseUpdate">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="CaseReference"/>
+
+                              <xs:element minOccurs="0" name="Priority" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="Severity" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="Title">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Description">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="4000"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Queue" type="FWTCaseQueue"/>
+
+                              <xs:element minOccurs="0" name="DueDate" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="AssociatedObject" type="FWTObjectID"/>
+
+                              <xs:element minOccurs="0" name="CurrentHandler" type="FWTUser"/>
+
+                              <xs:element minOccurs="0" name="Internal" type="xs:boolean"/>
+
+                              <xs:element minOccurs="0" name="Form" type="FWTCaseForm"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="NewNote" type="xs:string"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="NewNoteAttachment" type="FWTNoteAttachment"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="UpdateNote" type="FWTCaseNoteUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="UpdateNoteAttachment" type="FWTUpdateNoteAttachment"/>
+
+                              <xs:element minOccurs="0" ref="NewCaseReference">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    The supplied value is prepended to
+                                    the existing case reference,
+                                    separated by a hyphen, i.e. the
+                                    updated case reference is
+                                    NewCaseReference-CaseReference
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="BPMCaseUpdate" type="FWTBPMCaseUpdate"/>
+
+                              <xs:element minOccurs="0" name="Parent" type="FWTDomainObjectID"/>
+
+                              <xs:element minOccurs="0" name="XCoord" type="xs:string"/>
+
+                              <xs:element minOccurs="0" name="YCoord" type="xs:string"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTCaseUpdateResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FWTCalculateDueDateInput">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="1" minOccurs="1" name="SLATimePeriod" type="SLATimePeriodType"/>
+
+                              <xs:element maxOccurs="1" minOccurs="1" name="SLATimeValue" type="xs:int"/>
+
+                              <xs:element name="SLAWorkingTime" type="xs:boolean"/>
+
+                              <xs:element maxOccurs="1" minOccurs="0" name="SLACalendarKey" type="xs:string"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCalculateDueDateFinish">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="1" minOccurs="0" name="DueDate" type="xs:dateTime"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTCaseFinish">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" ref="CaseReference"/>
+
+                              <xs:element minOccurs="0" name="RescheduleDate" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="ReallocateQueue" type="FWTCaseQueue"/>
+
+                              <xs:element minOccurs="0" name="WorkFlowCompletionStatus" type="xs:string">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    complete, incomplete, reschedule
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element name="Reason" type="FWTCaseActionReason"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTCaseFinishResponse" type="FWTResponseStatus"/>
+
+               <xs:complexType name="FWTCaseEformInstance">
+
+                    <xs:sequence>
+
+                         <xs:element ref="CaseReference"/>
+
+                         <xs:element name="EformName">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="ContentRepositoryVersion">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Only to be used if eForm is stored in a content repository.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="50"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTEformField">
+
+                    <xs:sequence>
+
+                         <xs:element name="FieldName">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="FieldValue">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="4000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTEformFieldList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" name="EformFields" type="FWTEformField"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCaseEformData">
+
+                    <xs:sequence>
+
+                         <xs:element name="CaseEformInstance" type="FWTCaseEformInstance"/>
+
+                         <xs:element name="EformData" type="FWTEformFieldList"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCaseEformDataList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" name="CaseEformData" type="FWTCaseEformData"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FLEformFields" type="FWTCaseEformData"/>
+
+			   <xs:element name="FLEformFieldsResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FLEformData" type="FWTCaseEformData"/>
+
+               <xs:element name="FLCaseEformInstance" type="FWTCaseEformInstance"/>
+
+
+            <!--*************************************************************************-->
+
+            <!--  INTERACTION TYPES  -->
+
+            <!--*************************************************************************-->
+
+               <xs:element name="Channel" type="xs:string">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        ivr, voice_in, voice_out, email_in, email_out,
+                        fax_in, fax_out, web, wap, face_to_face,
+                        mail_in, mail_out, sms_in, sms_out
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+               </xs:element>
+
+               <xs:element name="InteractionID" type="xs:long"/>
+
+               <xs:complexType name="FWTInteractionDetails">
+
+                    <xs:sequence>
+
+                         <xs:element ref="InteractionID"/>
+
+                         <xs:element ref="Channel"/>
+
+                         <xs:element name="Verified" type="xs:boolean"/>
+
+                         <xs:element name="CreationDate" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="PartyID" type="FWTObjectID"/>
+
+                         <xs:element minOccurs="0" name="ChannelReference" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This is a reference to interaction
+                                collateral information where available.
+                                The item referenced depends on the type
+                                of interaction. For email, fax, sms and
+                                mail interactions the reference will be
+                                the internal identifier for the
+                                corresponding message record. For voice
+                                interactions it will be an identifier
+                                for a call record. For face to face
+                                interactions it will be an identifier
+                                for a face to face details record.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ChannelData" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This field is reserved for future use.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Relation">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                initial, linked
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string"/>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTInteractionDetailsList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" name="InteractionDetails" type="FWTInteractionDetails"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTInteractionCreate">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="Channel"/>
+
+                              <xs:element name="Verified" type="xs:boolean"/>
+
+                              <xs:element minOccurs="0" name="PartyID" type="FWTObjectID"/>
+
+                              <xs:element minOccurs="0" ref="CaseReference"/>
+
+                              <xs:element minOccurs="0" name="ChannelReference" type="xs:string">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    This is a reference to interaction
+                                    collateral information. It is not
+                                    possible currently to create
+                                    collateral data through the
+                                    webservice so this field can be
+                                    omitted.
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ChannelData" type="xs:string">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    This field is reserved for future
+                                    use.
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="NoteText">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="4000"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTInteractionUpdate">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="1" ref="InteractionID"/>
+
+                              <xs:element minOccurs="0" name="InteractionMessage" type="FWTInteractionMessage"/>
+
+                              <xs:element minOccurs="0" name="queueForInteractionMessage" type="xs:string"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTInteractionUpdateResponse" type="FWTResponseStatus"/>
+
+               <xs:complexType name="FWTInteractionMessage">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="from" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="to" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="sent" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="received" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="subject" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="content" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="messageType" type="xs:int">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Possible Values: LETTER=0(Default), EMAIL=1, FAX=2, SMS=3, GENERATED_LETTER=4
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="AttachedDocuments" type="FWTAttachedDocumentList"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTAttachedDocumentList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="1" name="AttachedDocument" type="FWTAttachedDocument"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTAttachedDocument">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="1" name="documentName" type="xs:string"/>
+
+                         <xs:element minOccurs="1" name="documentReference" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="storageType" type="xs:int">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+ Standard storage is 0        </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTInteractionCaseLink">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                both member elements are mandatory
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:element ref="InteractionID"/>
+
+                              <xs:element ref="CaseReference"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTInteractionCaseLinkResponse" type="FWTResponseStatus"/>
+
+
+            <!--*************************************************************************-->
+
+            <!--  ODM TYPES  -->
+
+            <!--*************************************************************************-->
+
+               <xs:element name="ObjectType" type="xs:string">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        C1=individual C2=organisation D3=property
+                        D4=street
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+               </xs:element>
+
+               <xs:element name="ObjectReference" nillable="true" type="xs:string">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        Should only ever be 80 characters
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+               </xs:element>
+
+               <xs:element name="ObjectDescription">
+
+                    <xs:simpleType>
+
+                         <xs:restriction base="xs:string">
+
+                              <xs:maxLength value="255"/>
+
+                         </xs:restriction>
+
+                    </xs:simpleType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTObjectID">
+
+                    <xs:sequence>
+
+                         <xs:annotation>
+
+                              <xs:documentation>
+
+                            The first reference is the object's unique
+                            identifier within ODM
+                              </xs:documentation>
+
+                         </xs:annotation>
+
+                         <xs:element ref="ObjectType"/>
+
+                         <xs:element maxOccurs="3" ref="ObjectReference"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:simpleType name="FWTRelationshipID">
+
+                    <xs:restriction base="xs:long"/>
+
+               </xs:simpleType>
+
+               <xs:element name="RelationshipType">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        Relationship type must match existing ODM
+                        configuration. Values are stored in the
+                        RelationshipType column in the
+                        LGNOM_PartyRelationshipType table.
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+                    <xs:simpleType>
+
+                         <xs:restriction base="xs:string">
+
+                              <xs:maxLength value="25"/>
+
+                         </xs:restriction>
+
+                    </xs:simpleType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTRelationship">
+
+                    <xs:sequence>
+
+                         <xs:element name="RelationshipID" type="FWTRelationshipID"/>
+
+                         <xs:element ref="RelationshipType"/>
+
+                         <xs:element minOccurs="0" name="StartDate" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="EndDate" type="xs:dateTime"/>
+
+                         <xs:element name="RelatedObject" type="FWTObjectID"/>
+
+                         <xs:element minOccurs="0" name="ExtraData" type="FWTCaseForm"/>
+
+                         <xs:element minOccurs="0" name="OwnerObject" type="FWTObjectID"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTRelationshipList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Relationship" type="FWTRelationship"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTRelationshipNew">
+
+                    <xs:sequence>
+
+                         <xs:element ref="RelationshipType"/>
+
+                         <xs:element minOccurs="0" name="StartDate" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="EndDate" type="xs:dateTime"/>
+
+                         <xs:element name="OwnerObject" type="FWTObjectID"/>
+
+                         <xs:element name="RelatedObject" type="FWTObjectID"/>
+
+                         <xs:element minOccurs="0" name="ExtraData" type="FWTCaseForm"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTRelationshipTimeframeUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="RelationshipID" type="FWTRelationshipID"/>
+
+                         <xs:element minOccurs="0" name="StartDate" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="EndDate" type="xs:dateTime"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTRelationshipFormDataUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="RelationshipID" type="FWTRelationshipID"/>
+
+                         <xs:element name="ExtraData" type="FWTCaseForm"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTPartyCluster">
+
+                    <xs:sequence>
+
+                         <xs:annotation>
+
+                              <xs:documentation>
+
+                            FWTPartyCluster is used to update the
+                            clusterId of the Parties in the list.
+                              </xs:documentation>
+
+                         </xs:annotation>
+
+                         <xs:element maxOccurs="unbounded" name="ObjectID" type="FWTObjectID"/>
+
+                         <xs:element name="ClusterID" type="xs:string"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTObjectIdList">
+
+                    <xs:sequence>
+
+                         <xs:annotation>
+
+                              <xs:documentation/>
+
+                         </xs:annotation>
+
+                         <xs:element maxOccurs="unbounded" name="ObjectID" type="FWTObjectID"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FLIndividualID" type="FWTObjectID"/>
+
+               <xs:element name="FLOrganisationID" type="FWTObjectID"/>
+
+               <xs:element name="FLPropertyID" type="FWTObjectID"/>
+
+               <xs:element name="FLStreetID" type="FWTObjectID"/>
+
+               <xs:element name="FLNewIndividualID" type="FWTObjectID"/>
+
+               <xs:element name="FLNewOrganisationID" type="FWTObjectID"/>
+
+               <xs:element name="FLPartyID" type="FWTObjectID"/>
+
+               <xs:element name="FLDeletePartyID" type="FWTDeleteParty"/>
+
+			   <xs:element name="FLDeletePartyIDResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FLRollbackMerge" type="FWTObjectID"/>
+
+			   <xs:element name="FLRollbackMergeResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FLPartyCluster" type="FWTPartyCluster"/>
+
+			   <xs:element name="FLPartyClusterResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FLObjectIdList" type="FWTObjectIdList"/>
+
+			   <xs:element name="FLObjectIdListResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FLRelationshipPartyID" type="FWTObjectID"/>
+
+               <xs:element name="FLRelationshipCreate" type="FWTRelationshipNew"/>
+
+               <xs:element name="FLRetreiveRelationship" type="FWTRelationship"/>
+
+               <xs:element name="FLRelationshipTimeframeUpdate" type="FWTRelationshipTimeframeUpdate"/>
+
+               <xs:element name="FLRelationshipFormDataUpdate" type="FWTRelationshipFormDataUpdate"/>
+
+               <xs:element name="FLDeleteRelationshipID" type="FWTRelationshipID"/>
+
+			   <xs:element name="FLDeleteRelationshipIDResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FLRetrieveRelationshipID" type="FWTRelationshipID"/>
+
+               <xs:element name="FLNewRelationshipID" type="FWTRelationshipID"/>
+
+               <xs:complexType name="FWTDeleteParty">
+
+                    <xs:sequence>
+
+                         <xs:element name="ObjectID" type="FWTObjectID"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Option">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Values: cdi
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="20"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:simpleType name="FWTObjectDescription">
+
+                    <xs:restriction base="xs:string">
+
+                         <xs:maxLength value="255"/>
+
+                    </xs:restriction>
+
+               </xs:simpleType>
+
+
+               <xs:complexType name="FWTObjectBriefDetails">
+
+                    <xs:sequence>
+
+                         <xs:annotation>
+
+                              <xs:documentation>
+
+                            ObjectDescription is not used in the party
+                            creation or update operations and should be
+                            left empty.
+                              </xs:documentation>
+
+                         </xs:annotation>
+
+                         <xs:element name="ObjectID" type="FWTObjectID"/>
+
+                         <xs:element ref="ObjectDescription"/>
+
+                         <xs:element minOccurs="0" name="Details">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="4000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Category" type="xs:int"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTObjectBriefDetailsList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ObjectBriefDetails" type="FWTObjectBriefDetails"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTObjectSearch">
+
+                    <xs:sequence>
+
+                         <xs:annotation>
+
+                              <xs:documentation>
+
+                            Supply reference or description
+                              </xs:documentation>
+
+                         </xs:annotation>
+
+                         <xs:element minOccurs="0" ref="ObjectReference"/>
+
+                         <xs:element minOccurs="0" ref="ObjectDescription"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="Usage" type="xs:string">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        unknown, home, work
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+               </xs:element>
+
+               <xs:element name="Preferred" type="xs:boolean"/>
+
+               <xs:complexType name="FWTContactPhone">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="PhoneID" type="xs:long">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This element is ignored on a create
+                                operation.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Number">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="DeviceType" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                fax, telephone, mobile, unknown
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element ref="Usage"/>
+
+                         <xs:element minOccurs="0" name="AuditDetails" type="FWTAuditDetails"/>
+
+                         <xs:element ref="Preferred"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ExtraData" type="FWTKeyValue"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="ListItemUpdateType" type="xs:string">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        Values: Update,Insert
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+               </xs:element>
+
+               <xs:complexType name="FWTContactPhoneUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="PhoneDetails" type="FWTContactPhone"/>
+
+                         <xs:element ref="ListItemUpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTContactEmail">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="EmailID" type="xs:long">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This element is ignored on a create
+                                operation.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element name="EmailAddress">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="255"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element ref="Usage"/>
+
+                         <xs:element minOccurs="0" name="AuditDetails" type="FWTAuditDetails"/>
+
+                         <xs:element ref="Preferred"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ExtraData" type="FWTKeyValue"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTContactEmailUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="EmailDetails" type="FWTContactEmail"/>
+
+                         <xs:element ref="ListItemUpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTContactPostal">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="AddressID" type="xs:long">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This element is ignored on a create
+                                operation.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="AddressNumber">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="50"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="6" name="AddressLine" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Only 3 address lines should be supplied
+                                for US addresses
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Postcode">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Not applicable for US addresses
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="8"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    <!-- The Usage field under contact postal should be ignored. -->
+
+                         <xs:element ref="Usage"/>
+
+                         <xs:element minOccurs="0" name="UPRN">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Not applicable for US addresses
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="12"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="City">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                For US addresses only
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="StateCode">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                For US addresses only
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="2"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Zipcode">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                For US addresses only
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="10"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="PropertyID">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                For US addresses only
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="50"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="POBox">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="10"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="PropertyStatus">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="AddressType">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefined" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedNum" nillable="true" type="xs:long"/>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedText" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="255"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedDate" nillable="true" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="StartDate" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="EndDate" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="AuditDetails" type="FWTAuditDetails"/>
+
+                         <xs:element ref="Preferred"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Option">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Values: use_uprn_for_address,
+                                ignore_invalid_uprn.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="20"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ExtraData" type="FWTKeyValue"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTContactPostalUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="PostalDetails" type="FWTContactPostal"/>
+
+                         <xs:element ref="ListItemUpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTIndividualName">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="NameID" type="xs:long">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This element is ignored on a create
+                                operation.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Title">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="3" minOccurs="0" name="Forename" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Initials">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="Surname">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="70"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="3" minOccurs="0" name="Suffix" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="FullName">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This field is ignored as the full name
+                                field is populated by a database trigger
+                                using the relevent name fields.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="255"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="RequestedName">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="70"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="DisplayType">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This field is not currently used.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="DateChange" type="xs:dateTime"/>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefined" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedNum" nillable="true" type="xs:long"/>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedText" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="255"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedDate" nillable="true" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="AuditDetails" type="FWTAuditDetails"/>
+
+                         <xs:element ref="Preferred"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="ExtraData" type="FWTKeyValue"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTIndividualNameUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="IndividualNameDetails" type="FWTIndividualName"/>
+
+                         <xs:element ref="ListItemUpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+               <xs:complexType name="FWTExtraData">
+
+                    <xs:sequence>
+
+                         <xs:annotation>
+
+                              <xs:documentation>
+
+                            ObjectDescription is not used in the party
+                            creation or update operations and should be
+                            left empty.
+                              </xs:documentation>
+
+                         </xs:annotation>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+            <!--
+                <xs:complexType name="FWTExtensionChildSet">
+                <xs:sequence>
+                <xs:annotation>
+                <xs:documentation>ObjectDescription is not used in the party creation or update operations and should be left empty.</xs:documentation>
+                </xs:annotation>
+                </xs:sequence>
+                </xs:complexType>
+            -->
+
+
+               <xs:complexType name="FWTOrganisationName">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="NameID" type="xs:long">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This element is ignored on a create
+                                operation.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element name="FullName">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="70"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="DisplayType">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="DateChange" type="xs:dateTime"/>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefined" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedNum" nillable="true" type="xs:long"/>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedText" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="255"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedDate" nillable="true" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="AuditDetails" type="FWTAuditDetails"/>
+
+                         <xs:element ref="Preferred"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTOrganisationNameUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="OrganisationNameDetails" type="FWTOrganisationName"/>
+
+                         <xs:element ref="ListItemUpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTIndividual">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ChildSet" type="FWTExtensionChildSet"/>
+
+                              <xs:element minOccurs="0" name="BriefDetails" type="FWTObjectBriefDetails"/>
+
+                              <xs:element maxOccurs="unbounded" name="Name" type="FWTIndividualName"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPostals" type="FWTContactPostal"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPhones" type="FWTContactPhone"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactEmails" type="FWTContactEmail"/>
+
+                              <xs:element minOccurs="0" name="Gender">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    F=Female M=Male U=Unknown
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="1"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="GenderAtBirth">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    F=Female M=Male U=Unknown
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="1"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PlaceOfBirth">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="CountryOfBirth">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Nationality">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="MaritalStatus">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    S=Single M=Married D=Divorced
+                                    W=Widowed N=Not Disclosed
+                                    P=Separated
+                                        </xs:documentation>
+
+                                        <xs:documentation>
+
+                                    These values may no longer be valid
+                                    if the default ODM configuration has
+                                    been changed.
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="1"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="DrivingLicenceNumber">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="DrivingLicencePatternID" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="AdditionalDrivingLicences" type="xs:boolean"/>
+
+                              <xs:element minOccurs="0" name="PassportNumber">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PassportNumberPatternID" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="AdditionalPassports" type="xs:boolean"/>
+
+                              <xs:element minOccurs="0" name="HealthNumber">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US individuals
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="NationalInsuranceNumber">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US individuals
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="9"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SocialSecurityNumber">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US individuals only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="11"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Ethnicity">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Disabilities" type="xs:boolean"/>
+
+                              <xs:element minOccurs="0" name="DisabilityRegNumber">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="DateOfBirth" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="Occupation">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="AdditionalOccupations" type="xs:boolean"/>
+
+                              <xs:element minOccurs="0" name="DateOfDeath" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="PreferredLanguage">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="2"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="ValidFromDate" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="ValidToDate" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="SurveyConsent">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    0=Does not consent, 1=Does Consent
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="1"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="RegistrationDetails">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="AuthenticationDetails">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="LGCode">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="AuthorisedView">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="1"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Category">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="FreeText">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="255"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefined" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedNum" nillable="true" type="xs:long"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedText" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="255"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedDate" nillable="true" type="xs:date"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="GenericSmalls" type="FWTGenericSmall"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="GenericBigs" type="FWTGenericBig"/>
+
+                              <xs:element minOccurs="0" name="AuditDetails" type="FWTAuditDetails"/>
+
+                              <xs:element minOccurs="0" name="MergePartyList" type="FWTMergePartyList"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Option">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Values: cdi .This element is only
+                                    used for creating an individual
+                                    record and is not populated when
+                                    used for retrieving an individual's
+                                    details.
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="20"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ExtraData" type="FWTKeyValue"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTIndividualUpdate">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ChildSet" type="FWTExtensionChildSet"/>
+
+                              <xs:element name="BriefDetails" type="FWTObjectBriefDetails"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Name" type="FWTIndividualNameUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPostals" type="FWTContactPostalUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPhones" type="FWTContactPhoneUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactEmails" type="FWTContactEmailUpdate"/>
+
+                              <xs:element minOccurs="0" name="GenderUpdate" type="FWTGenderUpdate"/>
+
+                              <xs:element minOccurs="0" name="GenderAtBirthUpdate" type="FWTGenderAtBirthUpdate"/>
+
+                              <xs:element minOccurs="0" name="PlaceOfBirthUpdate" type="FWTPlaceOfBirthUpdate"/>
+
+                              <xs:element minOccurs="0" name="CountryOfBirthUpdate" type="FWTCountryOfBirthUpdate"/>
+
+                              <xs:element minOccurs="0" name="NationalityUpdate" type="FWTNationalityUpdate"/>
+
+                              <xs:element minOccurs="0" name="MaritalStatusUpdate" type="FWTMaritalStatusUpdate"/>
+
+                              <xs:element minOccurs="0" name="DrivingLicenceNumberUpdate" type="FWTDrivingLicenceNumberUpdate"/>
+
+                              <xs:element minOccurs="0" name="DrivingLicencePatternIDUpdate" type="FWTDrivingLicencePatternIDUpdate"/>
+
+                              <xs:element minOccurs="0" name="AdditionalDrivingLicencesUpdate" type="FWTAdditionalDrivingLicencesUpdate"/>
+
+                              <xs:element minOccurs="0" name="PassportNumberUpdate" type="FWTPassportNumberUpdate"/>
+
+                              <xs:element minOccurs="0" name="PassportNumberPatternIDUpdate" type="FWTPassportNumberPatternIDUpdate"/>
+
+                              <xs:element minOccurs="0" name="AdditionalPassportsUpdate" type="FWTAdditionalPassportsUpdate"/>
+
+                              <xs:element minOccurs="0" name="HealthNumberUpdate" type="FWTHealthNumberUpdate"/>
+
+                              <xs:element minOccurs="0" name="NationalInsuranceNumberUpdate" type="FWTNationalInsuranceNumberUpdate"/>
+
+                              <xs:element minOccurs="0" name="SocialSecurityNumberUpdate" type="FWTSocialSecurityNumberUpdate"/>
+
+                              <xs:element minOccurs="0" name="EthnicityUpdate" type="FWTEthnicityUpdate"/>
+
+                              <xs:element minOccurs="0" name="DisabilitiesUpdate" type="FWTDisabilitiesUpdate"/>
+
+                              <xs:element minOccurs="0" name="DisabilityRegNumberUpdate" type="FWTDisabilityRegNumberUpdate"/>
+
+                              <xs:element minOccurs="0" name="DateOfBirthUpdate" type="FWTDateOfBirthUpdate"/>
+
+                              <xs:element minOccurs="0" name="OccupationUpdate" type="FWTOccupationUpdate"/>
+
+                              <xs:element minOccurs="0" name="AdditionalOccupationsUpdate" type="FWTAdditionalOccupationsUpdate"/>
+
+                              <xs:element minOccurs="0" name="DateOfDeathUpdate" type="FWTDateOfDeathUpdate"/>
+
+                              <xs:element minOccurs="0" name="PreferredLanguageUpdate" type="FWTPreferredLanguageUpdate"/>
+
+                              <xs:element minOccurs="0" name="ValidFromDateUpdate" type="FWTValidFromDateUpdate"/>
+
+                              <xs:element minOccurs="0" name="ValidToDateUpdate" type="FWTValidToDateUpdate"/>
+
+                              <xs:element minOccurs="0" name="SurveyConsentUpdate" type="FWTSurveyConsentUpdate"/>
+
+                              <xs:element minOccurs="0" name="RegistrationDetailsUpdate" type="FWTRegistrationDetailsUpdate"/>
+
+                              <xs:element minOccurs="0" name="AuthenticationDetailsUpdate" type="FWTAuthenticationDetailsUpdate"/>
+
+                              <xs:element minOccurs="0" name="LGCodeUpdate" type="FWTLGCodeUpdate"/>
+
+                              <xs:element minOccurs="0" name="AuthorisedViewUpdate" type="FWTAuthorisedViewUpdate"/>
+
+                              <xs:element minOccurs="0" name="CategoryUpdate" type="FWTCategoryUpdate"/>
+
+                              <xs:element minOccurs="0" name="FreeTextUpdate" type="FWTFreeTextUpdate"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedUpdate" nillable="true" type="FWTUserDefinedUpdate"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedNumUpdate" nillable="true" type="FWTUserDefinedNumUpdate"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedTextUpdate" nillable="true" type="FWTUserDefinedTextUpdate"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedDateUpdate" nillable="true" type="FWTUserDefinedDateUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="GenericSmallUpdates" type="FWTGenericSmallUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="GenericBigUpdates" type="FWTGenericBigUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Option">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Values: cdi. This element is only
+                                    used for updating an individual
+                                    record.
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="20"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ExtraData" type="FWTKeyValue"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTIndividualUpdateResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FWTOrganisation">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="0" name="BriefDetails" type="FWTObjectBriefDetails"/>
+
+                              <xs:element maxOccurs="unbounded" name="Name" type="FWTOrganisationName"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPostals" type="FWTContactPostal"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPhones" type="FWTContactPhone"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactEmails" type="FWTContactEmail"/>
+
+                              <xs:element minOccurs="0" name="LegalEntity" type="xs:boolean"/>
+
+                              <xs:element minOccurs="0" name="CreationDate" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="DissolutionDate" type="xs:date"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ChildSet" type="FWTExtensionChildSet"/>
+
+
+                              <xs:element minOccurs="0" name="CompanyReferenceNumber">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="OrganisationCode">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="20"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="VATNumber">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US organisations
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="20"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="VATNumberPatternID" type="xs:int">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US organisations
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="IndustryClassification">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="10"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="ValidFromDate" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="ValidToDate" type="xs:date"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefined" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedNum" nillable="true" type="xs:long"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedText" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="255"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedDate" nillable="true" type="xs:date"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="GenericSmalls" type="FWTGenericSmall"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="GenericBigs" type="FWTGenericBig"/>
+
+                              <xs:element minOccurs="0" name="AuditDetails" type="FWTAuditDetails"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Option">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Values: cdi. This element is only
+                                    used for creating an organisation
+                                    record and is not populated when
+                                    used for retrieving an
+                                    organisation's details.
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="20"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ExtraData" type="FWTKeyValue"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTOrganisationUpdate">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="BriefDetails" type="FWTObjectBriefDetails"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Name" type="FWTOrganisationNameUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPostals" type="FWTContactPostalUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactPhones" type="FWTContactPhoneUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ContactEmails" type="FWTContactEmailUpdate"/>
+
+                              <xs:element minOccurs="0" name="LegalEntityUpdate" type="FWTLegalEntityUpdate"/>
+
+                              <xs:element minOccurs="0" name="CreationDateUpdate" type="FWTCreationDateUpdate"/>
+
+                              <xs:element minOccurs="0" name="DissolutionDateUpdate" type="FWTDissolutionDateUpdate"/>
+
+                              <xs:element minOccurs="0" name="CompanyReferenceNumberUpdate" type="FWTCompanyReferenceNumberUpdate"/>
+
+                              <xs:element minOccurs="0" name="OrganisationCodeUpdate" type="FWTOrganisationCodeUpdate"/>
+
+                              <xs:element minOccurs="0" name="VATNumberUpdate" type="FWTVATNumberUpdate"/>
+
+                              <xs:element minOccurs="0" name="VATNumberPatternIDUpdate" type="FWTVATNumberPatternIDUpdate"/>
+
+                              <xs:element minOccurs="0" name="IndustryClassificationUpdate" type="FWTIndustryClassificationUpdate"/>
+
+                              <xs:element minOccurs="0" name="ValidFromDateUpdate" type="FWTValidFromDateUpdate"/>
+
+                              <xs:element minOccurs="0" name="ValidToDateUpdate" type="FWTValidToDateUpdate"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedUpdate" nillable="true" type="FWTUserDefinedUpdate"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedNumUpdate" nillable="true" type="FWTUserDefinedNumUpdate"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedTextUpdate" nillable="true" type="FWTUserDefinedTextUpdate"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedDateUpdate" nillable="true" type="FWTUserDefinedDateUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="GenericSmallUpdates" type="FWTGenericSmallUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="GenericBigUpdates" type="FWTGenericBigUpdate"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Option">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Values: cdi . This element is only
+                                    used for updating an organisation's
+                                    record.
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="20"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ChildSet" type="FWTExtensionChildSet"/>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="ExtraData" type="FWTKeyValue"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTOrganisationUpdateResponse" type="FWTResponseStatus"/>
+
+               <xs:complexType name="FWTGenericSmall">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="RecordID" type="xs:long">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This element is ignored on a create
+                                operation.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element name="RecordType">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Value1">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Value2">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="RangeFrom">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="RangeTo">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Date1" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="Date2" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="StartDate" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="EndDate" type="xs:date"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTGenericSmallUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="GenericSmallDetails" type="FWTGenericSmall"/>
+
+                         <xs:element ref="ListItemUpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTGenericBig">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="RecordID" type="xs:long">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                This element is ignored on a create
+                                operation.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element name="RecordType">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="RecordIndex" type="xs:int"/>
+
+                         <xs:element minOccurs="0" name="Value1">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Value2">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Value3">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Value4">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Value5">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Range1From">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Range1To">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Range2From">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Range2To">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Range3From">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Range3To">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Date1" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="Date2" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="Date3" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="Date4" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="Date5" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="StartDate" type="xs:date"/>
+
+                         <xs:element minOccurs="0" name="EndDate" type="xs:date"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTGenericBigUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element name="GenericBigDetails" type="FWTGenericBig"/>
+
+                         <xs:element ref="ListItemUpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTPartySearch">
+
+                    <xs:complexType>
+
+                         <xs:annotation>
+
+                              <xs:documentation>
+
+                            The following items are not used for
+                            Organisation search: Forename, Forename2,
+                            NationalInsuranceNumber,
+                            SocialSecurityNumber, DateOfBirth
+                              </xs:documentation>
+
+                         </xs:annotation>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="1" name="SearchType">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    individual, organisation, party
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string"/>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" ref="SearchMatch"/>
+
+                              <xs:element minOccurs="0" name="Name">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Surname or organisation name
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="70"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Forename">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Forename2">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="DateOfBirth" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="NationalInsuranceNumber">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US individuals
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="9"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SocialSecurityNumber">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US individuals only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="11"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Postcode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="8"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="AddressNumber">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="StreetName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="City">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="StateCode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="2"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Zipcode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="10"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PhoneNumber">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="EmailAddress">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="255"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="GenericValue">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTProperty">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="BriefDetails" type="FWTObjectBriefDetails"/>
+
+                              <xs:element minOccurs="0" name="UPRN">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="12"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="USRN">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="8"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAO">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="12"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAO">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="12"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PropertyID">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element name="AddressNumber">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element name="AddressLine1">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="AddressLine2">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element name="PrimaryStreetName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Locality">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Town">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses -
+                                    use City
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Postcode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="8"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="City">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="StateCode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="2"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Zipcode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="10"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="County">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Country">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="POBox">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="10"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="BuildingName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="2" minOccurs="0" name="PrimaryStreetAltName" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SecondaryStreetName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="2" minOccurs="0" name="SecondaryStreetAltName" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="IGGeoCode">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="12"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="GPSItmGeoCode">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="12"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="GPSUtmGeoCode">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="12"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="LocalCouncilCode" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="LocalCouncilName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="RegionalCouncilCode" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="RegionalCouncilName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="WardRef" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="WardName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="LocalityType">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SecondaryLocality">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="TownlandRef" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="TownlandName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PostTownRef" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="CityRef" type="xs:long">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="CountyRef" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="CountryRef" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="BuildingUse">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="BuildingStatus">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="PAOUserDefined" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="PAOUserDefinedNum" nillable="true" type="xs:long"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="PAOUserDefinedText" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="255"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="PAOUserDefinedDate" nillable="true" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="PAOStartDate" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="PAOEndDate" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="SubBuildingName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="OrganisationName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="BusinessAlias">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="DepartmentName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="LargeUserPostCode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="8"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SubBuildingStatus">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="BusinessUse">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="RMDeliveryPointSuffix">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="2"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="RMAddressKey" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="VLARef" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="OrdnanceSurveyRef" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="DeliveryPointStatus">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="10"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="RecordStatusIndicator">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="20"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="SAOUserDefined" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="SAOUserDefinedNum" nillable="true" type="xs:long"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="SAOUserDefinedText" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="255"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="SAOUserDefinedDate" nillable="true" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="SAOStartDate" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="SAOEndDate" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="PAOAuditDetails" type="FWTAuditDetails"/>
+
+                              <xs:element minOccurs="0" name="SAOAuditDetails" type="FWTAuditDetails"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTPropertySearch">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="0" ref="SearchMatch"/>
+
+                              <xs:element minOccurs="0" name="AddressNumber">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Postcode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="8"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UPRN">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="12"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAO">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="12"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="StreetName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Locality">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAO">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="12"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Town">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses -
+                                    use City
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="USRN">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="8"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PropertyID">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="StreetName2">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="City">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="StateCode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="2"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Zipcode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="10"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="BuildingName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SubBuildingName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined1">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined2">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined3">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined4">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined5">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined6">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined7">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined8">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined9">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PAOUserDefined10">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined1">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined2">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined3">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined4">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined5">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined6">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined7">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined8">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined9">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="SAOUserDefined10">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTStreet">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="BriefDetails" type="FWTObjectBriefDetails"/>
+
+                              <xs:element minOccurs="0" name="USRN">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="8"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element name="StreetName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PrimaryLocality">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element name="PostTownName">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses -
+                                    use City
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="CountyName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="City">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="StateCode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="2"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element name="Primary" type="xs:boolean"/>
+
+                              <xs:element maxOccurs="2" minOccurs="0" name="AlternativeStreetName" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="LocalityType">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="25"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PostTownRef" type="xs:long">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses -
+                                    use CityRef
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="CityRef" type="xs:long">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="CountyRef" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="LocalCouncilCode" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="LocalCouncilName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefined" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedNum" nillable="true" type="xs:long"/>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedText" nillable="true">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="255"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="10" minOccurs="0" name="UserDefinedDate" nillable="true" type="xs:date"/>
+
+                              <xs:element minOccurs="0" name="AuditDetails" type="FWTAuditDetails"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTStreetSearch">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="0" ref="SearchMatch"/>
+
+                              <xs:element minOccurs="0" name="StreetName">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Locality">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="35"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="Town">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses -
+                                    use City
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="50"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="USRN">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Not applicable for US addresses
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="8"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="City">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="100"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="StateCode">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    For US addresses only
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="2"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined1">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined2">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined3">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined4">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined5">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined6">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined7">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined8">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined9">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="UserDefined10">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="80"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="SearchMatch" type="xs:string">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        equals, equals_ignore_case, like,
+                        like_ignore_case (default), soundex
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+               </xs:element>
+
+               <xs:element name="UpdateType" type="xs:string">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        Use value 'Clear' to clear the associated
+                        field's current value. To update the associated
+                        field, supply a value and no UpdateType element.
+                        To leave the associated field as is, supply no
+                        value and no UpdateType element.
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+               </xs:element>
+
+               <xs:complexType name="FWTCreationDateUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="CreationDate" nillable="true" type="xs:date"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTLegalEntityUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="LegalEntity" nillable="true" type="xs:boolean"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTDissolutionDateUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="DissolutionDate" nillable="true" type="xs:date"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCompanyReferenceNumberUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="CompanyReferenceNumber" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTOrganisationCodeUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="OrganisationCode" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="20"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTVATNumberUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="VATNumber" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Not applicable for US organisations
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="20"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTVATNumberPatternIDUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="VATNumberPatternID" nillable="true" type="xs:int">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Not applicable for US organisations
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTIndustryClassificationUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="IndustryClassification" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="10"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTValidFromDateUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="ValidFromDate" nillable="true" type="xs:date"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTValidToDateUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="ValidToDate" nillable="true" type="xs:date"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTUserDefinedUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="UserDefined" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                User-defined fields are updated based on
+                                index. Therefore if only one is supplied
+                                it is assumed that this is user-defined
+                                field 1. To update user-defined field 5
+                                you would need to also supply the first
+                                4 fields, these may be empty if no
+                                change is required.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTUserDefinedNumUpdate">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        User-defined fields are updated based on index.
+                        Therefore if only one is supplied it is assumed
+                        that this is user-defined field 1. To update
+                        user-defined field 5 you would need to also
+                        supply the first 4 fields, these may be empty if
+                        no change is required.
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="UserDefinedNum" nillable="true" type="xs:long"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTUserDefinedTextUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="UserDefinedText" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                User-defined fields are updated based on
+                                index. Therefore if only one is supplied
+                                it is assumed that this is user-defined
+                                field 1. To update user-defined field 5
+                                you would need to also supply the first
+                                4 fields, these may be empty if no
+                                change is required.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="255"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTUserDefinedDateUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="UserDefinedDate" nillable="true" type="xs:date">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                User-defined fields are updated based on
+                                index. Therefore if only one is supplied
+                                it is assumed that this is user-defined
+                                field 1. To update user-defined field 5
+                                you would need to also supply the first
+                                4 fields, these may be empty if no
+                                change is required.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTGenderUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="Gender" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                F=Female M=Male U=Unknown
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="1"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTGenderAtBirthUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="GenderAtBirth" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                F=Female M=Male U=Unknown
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="1"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTPlaceOfBirthUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="PlaceOfBirth" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCountryOfBirthUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="CountryOfBirth" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTNationalityUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="Nationality" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTMaritalStatusUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="MaritalStatus" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                S=Single M=Married D=Divorced W=Widowed
+                                N=Not Disclosed P=Separated
+                                   </xs:documentation>
+
+                                   <xs:documentation>
+
+                                These values may no longer be valid if
+                                the default ODM configuration has been
+                                changed.
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="1"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTDrivingLicenceNumberUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="DrivingLicenceNumber" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTDrivingLicencePatternIDUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="DrivingLicencePatternID" nillable="true" type="xs:int"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTAdditionalDrivingLicencesUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="AdditionalDrivingLicences" nillable="true" type="xs:boolean"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTPassportNumberUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="PassportNumber" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTPassportNumberPatternIDUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="PassportNumberPatternID" nillable="true" type="xs:int"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTAdditionalPassportsUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="AdditionalPassports" nillable="true" type="xs:boolean"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTHealthNumberUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="HealthNumber" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Not applicable for US individuals
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="50"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTNationalInsuranceNumberUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="NationalInsuranceNumber" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Not applicable for US individuals
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="9"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTSocialSecurityNumberUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="SocialSecurityNumber" nillable="true">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                For US individuals only
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="11"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTEthnicityUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="Ethnicity" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTDisabilitiesUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="Disabilities" nillable="true" type="xs:boolean"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTDisabilityRegNumberUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="DisabilityRegNumber" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTDateOfBirthUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="DateOfBirth" nillable="true" type="xs:date"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTOccupationUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="Occupation" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="35"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTAdditionalOccupationsUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="AdditionalOccupations" nillable="true" type="xs:boolean"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTDateOfDeathUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="DateOfDeath" nillable="true" type="xs:date"/>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTPreferredLanguageUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="PreferredLanguage" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="2"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTSurveyConsentUpdate">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        0=Does not consent, 1=Does Consent
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="SurveyConsent" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="1"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTRegistrationDetailsUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="RegistrationDetails" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTAuthenticationDetailsUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="AuthenticationDetails" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTLGCodeUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="LGCode" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTAuthorisedViewUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="AuthorisedView" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="1"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCategoryUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="Category" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTFreeTextUpdate">
+
+                    <xs:sequence>
+
+                         <xs:element minOccurs="0" name="FreeText" nillable="true">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="255"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" ref="UpdateType"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTMergeCreate">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="TargetParty" type="FWTObjectID"/>
+
+                              <xs:element maxOccurs="unbounded" name="MergeParties" type="FWTObjectID"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="MergeID" type="xs:long"/>
+
+               <xs:complexType name="FWTMergePartyList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" name="MergeParties" type="FWTObjectID"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+
+               <xs:element name="FLExtensionPartyID" type="FWTObjectID"/>
+
+
+
+               <xs:element name="FLExtensionObjectID" type="FWTObjectID"/>
+
+
+               <xs:element name="FLNewExtensionObjectID" type="FWTObjectID"/>
+
+               <xs:element name="FLNewExtensionPartyID" type="FWTObjectID"/>
+
+
+               <xs:element name="FLExtensionParty" type="FWTExtensionParty"/>
+
+               <xs:element name="FLExtensionPartyCreate" type="FWTExtensionParty"/>
+
+               <xs:element name="FLExtensionPartyUpdate" type="FWTExtensionParty"/>
+
+			   <xs:element name="FLExtensionPartyUpdateResponse" type="FWTResponseStatus"/>
+
+
+               <xs:element name="FLExtensionObject" type="FWTExtensionObject"/>
+
+               <xs:element name="FLExtensionObjectCreate" type="FWTExtensionObject"/>
+
+               <xs:element name="FLExtensionObjectUpdate" type="FWTExtensionObject"/>
+
+			   <xs:element name="FLExtensionObjectUpdateResponse" type="FWTResponseStatus"/>
+
+
+
+               <xs:element name="FWTObjectSearchCriteria">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="0" name="SearchType">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Numeric type of the search to be
+                                    performed
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:int"/>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Criteria" type="FWTKeyValue"/>
+
+                              <xs:element minOccurs="0" name="Options">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Options for the search, dependent on
+                                    search type
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="255"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+
+
+            <!--*************************************************************************-->
+
+            <!--  MESSAGING TYPES  -->
+
+            <!--*************************************************************************-->
+
+               <xs:element name="MessageAgeLimit" type="xs:int">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        Express message age limit as a number of days,
+                        or supply -1 for no age limit
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+               </xs:element>
+
+               <xs:element name="Subject">
+
+                    <xs:simpleType>
+
+                         <xs:restriction base="xs:string">
+
+                              <xs:maxLength value="100"/>
+
+                         </xs:restriction>
+
+                    </xs:simpleType>
+
+               </xs:element>
+
+               <xs:element name="Text">
+
+                    <xs:simpleType>
+
+                         <xs:restriction base="xs:string">
+
+                              <xs:maxLength value="2000"/>
+
+                         </xs:restriction>
+
+                    </xs:simpleType>
+
+               </xs:element>
+
+               <xs:element name="MessageID" type="xs:int"/>
+
+               <xs:element name="GeneralMessageID" type="xs:int"/>
+
+               <xs:element name="PartyMessageID" type="xs:int"/>
+
+               <xs:complexType name="FWTMessageGeneral">
+
+                    <xs:sequence>
+
+                         <xs:element ref="MessageID"/>
+
+                         <xs:element minOccurs="0" ref="Subject"/>
+
+                         <xs:element minOccurs="0" ref="Text"/>
+
+                         <xs:element name="Created" type="xs:dateTime"/>
+
+                         <xs:element name="CreatedBy" type="FWTUser"/>
+
+                         <xs:element name="Read" type="xs:boolean"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTMessageGeneralList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Message" type="FWTMessageGeneral"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTMessageGeneralNew">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="Subject"/>
+
+                              <xs:element ref="Text"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTMessageParty">
+
+                    <xs:sequence>
+
+                         <xs:element ref="MessageID"/>
+
+                         <xs:element minOccurs="0" ref="Subject"/>
+
+                         <xs:element minOccurs="0" ref="Text"/>
+
+                         <xs:element name="Created" type="xs:dateTime"/>
+
+                         <xs:element name="CreatedBy" type="FWTUser"/>
+
+                         <xs:element name="Party" type="FWTObjectID"/>
+
+                         <xs:element name="HighPriority" type="xs:boolean"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTMessagePartyList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Message" type="FWTMessageParty"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTMessagePartyNew">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="Party" type="FWTObjectID"/>
+
+                              <xs:element ref="Subject"/>
+
+                              <xs:element ref="Text"/>
+
+                              <xs:element name="HighPriority" type="xs:boolean"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+
+            <!--*************************************************************************-->
+
+            <!--  EVENT TYPES  -->
+
+            <!--*************************************************************************-->
+
+               <xs:element name="FWTEventType" type="xs:int">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+
+                        1 = core events, 2 = custom script events, 3 =
+                        integrator java events, 4 = browser events
+                         </xs:documentation>
+
+                    </xs:annotation>
+
+               </xs:element>
+
+               <xs:complexType name="FWTEvent">
+
+                    <xs:sequence>
+
+                         <xs:element name="EventCode" type="FWTEventCode"/>
+
+                         <xs:element name="EventName">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="30"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="EventDescription">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="200"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTEventList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Event" type="FWTEvent"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTRuleEngineItem">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="1" minOccurs="1" name="Name" type="xs:string"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Value" type="FWTKeyValue"/>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Children" type="FWTRuleEngineItem"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTRuleEngineCriteria">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="1" name="RuleSet" type="xs:long"/>
+
+                              <xs:element minOccurs="1" name="CaseId" type="xs:long"/>
+
+                              <xs:element minOccurs="1" name="UserId" type="xs:string"/>
+
+                              <xs:element minOccurs="1" name="Data">
+
+                                   <xs:complexType>
+
+                                        <xs:sequence>
+
+                                             <xs:element maxOccurs="unbounded" minOccurs="1" name="FWTRuleEngineItem" type="FWTRuleEngineItem"/>
+
+                                        </xs:sequence>
+
+                                   </xs:complexType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTRuleEngineResults">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="0" name="SessionID" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="Output">
+
+                                   <xs:complexType>
+
+                                        <xs:sequence>
+
+                                             <xs:element maxOccurs="unbounded" minOccurs="1" name="FWTRuleEngineItem" type="FWTRuleEngineItem"/>
+
+                                        </xs:sequence>
+
+                                   </xs:complexType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+            <!-- Code Book types -->
+
+               <xs:element name="CodeBookName">
+
+                    <xs:simpleType>
+
+                         <xs:restriction base="xs:string">
+
+                              <xs:maxLength value="50"/>
+
+                         </xs:restriction>
+
+                    </xs:simpleType>
+
+               </xs:element>
+
+               <xs:element name="CodeKey">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+Code key format is &lt;codebook&gt;.&lt;code&gt;     </xs:documentation>
+
+                    </xs:annotation>
+
+                    <xs:simpleType>
+
+                         <xs:restriction base="xs:string">
+
+                              <xs:maxLength value="100"/>
+
+                         </xs:restriction>
+
+                    </xs:simpleType>
+
+               </xs:element>
+
+               <xs:simpleType name="CodeGroup">
+
+                    <xs:restriction base="xs:string">
+
+                         <xs:maxLength value="15"/>
+
+                    </xs:restriction>
+
+               </xs:simpleType>
+
+               <xs:element name="CodeValue">
+
+                    <xs:simpleType>
+
+                         <xs:restriction base="xs:string">
+
+                              <xs:maxLength value="50"/>
+
+                         </xs:restriction>
+
+                    </xs:simpleType>
+
+               </xs:element>
+
+               <xs:simpleType name="CodeDescription">
+
+                    <xs:restriction base="xs:string">
+
+                         <xs:maxLength value="250"/>
+
+                    </xs:restriction>
+
+               </xs:simpleType>
+
+               <xs:simpleType name="Filter">
+
+                    <xs:restriction base="xs:string">
+
+                         <xs:maxLength value="100"/>
+
+                    </xs:restriction>
+
+               </xs:simpleType>
+
+               <xs:simpleType name="Attribute">
+
+                    <xs:restriction base="xs:string">
+
+                         <xs:maxLength value="100"/>
+
+                    </xs:restriction>
+
+               </xs:simpleType>
+
+               <xs:complexType name="FWTCode">
+
+                    <xs:sequence>
+
+                         <xs:element name="CodeID" type="xs:long"/>
+
+                         <xs:element ref="CodeKey"/>
+
+                         <xs:element ref="CodeValue"/>
+
+                         <xs:element minOccurs="0" name="Description" type="CodeDescription"/>
+
+                         <xs:element ref="CodeBookName"/>
+
+                         <xs:element minOccurs="0" name="StartDate" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="EndDate" type="xs:dateTime"/>
+
+                         <xs:element minOccurs="0" name="CodeGroup1" type="CodeGroup"/>
+
+                         <xs:element minOccurs="0" name="CodeGroup2" type="CodeGroup"/>
+
+                         <xs:element minOccurs="0" name="CodeGroup3" type="CodeGroup"/>
+
+                         <xs:element minOccurs="0" name="Filter1" type="Filter"/>
+
+                         <xs:element minOccurs="0" name="Filter2" type="Filter"/>
+
+                         <xs:element minOccurs="0" name="Filter3" type="Filter"/>
+
+                         <xs:element minOccurs="0" name="Filter4" type="Filter"/>
+
+                         <xs:element minOccurs="0" name="Filter5" type="Filter"/>
+
+                         <xs:element minOccurs="0" name="Attribute1" type="Attribute"/>
+
+                         <xs:element minOccurs="0" name="Attribute2" type="Attribute"/>
+
+                         <xs:element minOccurs="0" name="Attribute3" type="Attribute"/>
+
+                         <xs:element minOccurs="0" name="Attribute4" type="Attribute"/>
+
+                         <xs:element minOccurs="0" name="Attribute5" type="Attribute"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTCodeList">
+
+                    <xs:sequence>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Code" type="FWTCode"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTCodeBook">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="CodeBookID" type="xs:long"/>
+
+                              <xs:element ref="CodeBookName"/>
+
+                              <xs:element minOccurs="0" name="Description" type="CodeDescription"/>
+
+                              <xs:element name="Published" type="xs:boolean"/>
+
+                              <xs:element minOccurs="0" name="StartDate" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="EndDate" type="xs:dateTime"/>
+
+                              <xs:element name="Codes" type="FWTCodeList"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTLinkedCase">
+
+                    <xs:sequence>
+
+                         <xs:element name="LinkedCase" type="FWTCaseReference"/>
+
+                         <xs:element minOccurs="0" name="Key" type="xs:string"/>
+
+                         <xs:element name="Inverse" type="xs:boolean"/>
+
+                         <xs:element minOccurs="0" name="InvertedKey" type="xs:string"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:element name="FWTSearchAndRetrieveCase">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="FWTCaseSearch"/>
+
+                              <xs:element maxOccurs="unbounded" name="Option">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+
+                                    Values: all, core, eforms-r,
+                                    eforms-rw, events, form, fullform,
+                                    notes, tasks, workflow,
+                                    interactions, eform-data, linkcases
+                                        </xs:documentation>
+
+                                   </xs:annotation>
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="20"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTDomainObjectID">
+
+                    <xs:sequence>
+
+                         <xs:element name="Type">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Values: odmobject, case, eform, note, interaction
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="25"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element name="Identifier">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="80"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTSidAccessPermissions">
+
+                    <xs:sequence>
+
+                         <xs:element name="Type">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+
+                                Values: user, group, everyone
+                                   </xs:documentation>
+
+                              </xs:annotation>
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="8"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="Sid">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="100"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element minOccurs="0" name="GrantMask" type="xs:int"/>
+
+                         <xs:element minOccurs="0" name="DenyMask" type="xs:int"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+               <xs:element name="FWTSidAccessPermissionsList">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="SidAccessPermissions" type="FWTSidAccessPermissions"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="DomainObjectID" type="FWTDomainObjectID"/>
+
+               <xs:element name="FWTSetAcl">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="DomainObjectID"/>
+
+                              <xs:element ref="FWTSidAccessPermissionsList"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTSetSidAccessPermissions">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="DomainObjectID"/>
+
+                              <xs:element ref="FWTSidAccessPermissionsList"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTInsertSidAccessPermissions">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="DomainObjectID"/>
+
+                              <xs:element ref="FWTSidAccessPermissionsList"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTRemoveSidAccessPermissions">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element ref="DomainObjectID"/>
+
+                              <xs:element ref="FWTSidAccessPermissionsList"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTNoteAttachment">
+
+                    <xs:sequence>
+
+                         <xs:element name="NoteText">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="4000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="1" minOccurs="1" name="AttachmentName" type="xs:string"/>
+
+                         <xs:element maxOccurs="1" minOccurs="1" name="AttachmentIdentifier" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="AttachmentType" type="xs:int"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTUpdateNoteAttachment">
+
+                    <xs:sequence>
+
+                         <xs:element name="NoteID" type="xs:long"/>
+
+                         <xs:element name="NoteText">
+
+                              <xs:simpleType>
+
+                                   <xs:restriction base="xs:string">
+
+                                        <xs:maxLength value="4000"/>
+
+                                   </xs:restriction>
+
+                              </xs:simpleType>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="1" minOccurs="1" name="AttachmentName" type="xs:string"/>
+
+                         <xs:element maxOccurs="1" minOccurs="1" name="AttachmentIdentifier" type="xs:string"/>
+
+                         <xs:element minOccurs="0" name="AttachmentType" type="xs:int"/>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+
+            <!-- Lucene Search -->
+
+               <xs:element name="FWTSearchCriteria">
+
+                    <xs:annotation>
+
+                         <xs:documentation>
+Paging is not currently supported. All matches are returned.     </xs:documentation>
+
+                    </xs:annotation>
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="QueryString" type="xs:string">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+A Lucene query string. See http://lucene.apache.org/java/docs/queryparsersyntax.html        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="ResultDetail" type="xs:string">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+Values: basic, full. Identifies the level of detail returned for each search hit. Defaults to basic.        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="StartIndex" type="xs:int">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+Index of the first hit to return. Defaults to 0        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="PageSize" type="xs:int">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+Number of hits to return, beginning at StartIndex. Defaults to pre-configured maximum. See services.properties        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTSearchResult">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element name="TotalHits" type="xs:int">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+Total number of hits found        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element name="StartIndex" type="xs:int">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+The index of the first hit returned by this call        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element name="PageSize" type="xs:int">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+Number of hits returned by this call        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element name="ElapsedMilliseconds" type="xs:long">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+The elapsed search time in milliseconds        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                              <xs:element maxOccurs="unbounded" minOccurs="0" name="Hit" type="FWTSearchHit">
+
+                                   <xs:annotation>
+
+                                        <xs:documentation>
+The list of hits, possibly empty        </xs:documentation>
+
+                                   </xs:annotation>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:complexType name="FWTSearchHit">
+
+                    <xs:sequence>
+
+                         <xs:element name="ID" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+Domain object identifier       </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element name="Type" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+Domain object type. Examples: odmobject, case       </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element name="Title" type="xs:string">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+A short textual description of the object       </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element name="Score" type="xs:float">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+The search score for this hit       </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                         <xs:element maxOccurs="unbounded" minOccurs="0" name="Field" type="FWTSearchHitField">
+
+                              <xs:annotation>
+
+                                   <xs:documentation>
+A list of fields belonging to this object       </xs:documentation>
+
+                              </xs:annotation>
+
+                         </xs:element>
+
+                    </xs:sequence>
+
+               </xs:complexType>
+
+               <xs:complexType name="FWTSearchHitField">
+
+                    <xs:attribute name="relationship" type="xs:string" use="optional"/>
+
+                    <xs:attribute name="rowID" type="xs:string" use="optional"/>
+
+                    <xs:attribute name="source" type="xs:string" use="optional"/>
+
+                    <xs:attribute name="childRowID" type="xs:string" use="optional"/>
+
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+
+                    <xs:attribute name="value" type="xs:string" use="required"/>
+
+               </xs:complexType>
+
+
+            <!--*************************************************************************-->
+
+            <!--  FACE TO FACE TYPES  -->
+
+            <!--*************************************************************************-->
+
+               <xs:element name="FWTFaceToFaceHeader">
+
+                    <xs:complexType>
+
+                         <xs:sequence>
+
+                              <xs:element minOccurs="0" name="InteractionDate" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="BranchID" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="TicketNumber">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="10"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+               <xs:element name="FWTFaceToFaceConversation">
+
+                    <xs:complexType>
+
+                         <xs:annotation>
+
+                              <xs:documentation>
+Both the Duration and WaitingTime should be supplied in seconds      </xs:documentation>
+
+                         </xs:annotation>
+
+                         <xs:sequence>
+
+                              <xs:element name="FaceToFaceID" type="xs:long"/>
+
+                              <xs:element minOccurs="0" name="StartDate" type="xs:dateTime"/>
+
+                              <xs:element minOccurs="0" name="Duration" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="Counter" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="Queue" type="xs:int"/>
+
+                              <xs:element minOccurs="0" name="WaitingTime" type="xs:int"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTFaceToFaceConversationResponse" type="FWTResponseStatus"/>
+
+               <xs:element name="FWTFaceToFaceID" type="xs:long"/>
+
+               <xs:element name="FWTReopenCaseRequest">
+
+                    <xs:complexType>
+
+                         <xs:annotation>
+
+                              <xs:documentation>
+Reopening of case      </xs:documentation>
+
+                         </xs:annotation>
+
+                         <xs:sequence>
+
+                              <xs:element ref="CaseReference"/>
+
+                              <xs:choice maxOccurs="1" minOccurs="1">
+
+                                   <xs:element name="AllocateToUser" nillable="false" type="FWTUserID"/>
+
+                                   <xs:element name="AllocateToQueueByName" nillable="false" type="FWTCaseQueue"/>
+
+                              </xs:choice>
+
+                              <xs:element minOccurs="0" name="Reason">
+
+                                   <xs:simpleType>
+
+                                        <xs:restriction base="xs:string">
+
+                                             <xs:maxLength value="4000"/>
+
+                                        </xs:restriction>
+
+                                   </xs:simpleType>
+
+                              </xs:element>
+
+                              <xs:element minOccurs="0" name="resetTaskSLAs" type="xs:boolean"/>
+
+                         </xs:sequence>
+
+                    </xs:complexType>
+
+               </xs:element>
+
+			   <xs:element name="FWTReopenCaseRequestResponse" type="FWTResponseStatus"/>
+
+
+               <xs:simpleType name="SLATimePeriodType">
+
+                    <xs:restriction base="xs:string">
+
+                         <xs:enumeration value="SECOND"/>
+
+                         <xs:enumeration value="MINUTE"/>
+
+                         <xs:enumeration value="HOUR"/>
+
+                         <xs:enumeration value="DAY"/>
+
+                         <xs:enumeration value="WEEK"/>
+
+                         <xs:enumeration value="MONTH"/>
+
+                    </xs:restriction>
+
+               </xs:simpleType>
+
+	        <!--  Audit Service Elements -->
+
+	           <xs:element name="FWTAuditMethodDescriptor">
+
+	               <xs:complexType>
+
+	                    <xs:annotation>
+
+	                         <xs:documentation>
+Interface Name and method name must be provided      </xs:documentation>
+
+	                    </xs:annotation>
+
+	                    <xs:sequence>
+
+	                         <xs:element maxOccurs="1" minOccurs="1" name="InterfaceName" type="xs:string"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="1" name="MethodName" type="xs:string"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="0" name="DomainArea" type="xs:string"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="1" name="OperationType" type="xs:string"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="1" name="Audited" type="xs:boolean"/>
+
+	                    </xs:sequence>
+
+	               </xs:complexType>
+
+	       	    </xs:element>
+
+
+	           <xs:element name="FWTUpdateAuditMethodResponse" type="FWTResponseStatus"/>
+
+
+	           <xs:element name="FWTAuditableServiceNamesRequest">
+
+	        	    <xs:complexType/>
+
+	           </xs:element>
+
+
+	           <xs:simpleType name="FWTAuditableServiceName">
+
+	                    <xs:restriction base="xs:string"/>
+
+	           </xs:simpleType>
+
+	           <xs:element name="FWTAuditableServiceNamesList">
+
+	               <xs:complexType>
+
+	                    <xs:sequence>
+
+	                         <xs:element maxOccurs="100" minOccurs="0" name="auditableServiceName" type="FWTAuditableServiceName"/>
+
+	                    </xs:sequence>
+
+	               </xs:complexType>
+
+	           </xs:element>
+
+
+	           <xs:element name="FWTAuditableServiceOperationsRequest" type="FWTAuditableServiceName"/>
+
+
+	           <xs:element name="FWTAuditableServiceOperationsList">
+
+		            <xs:complexType>
+
+		                 <xs:sequence>
+
+		                      <xs:element maxOccurs="100" minOccurs="0" ref="FWTAuditMethodDescriptor"/>
+
+		                 </xs:sequence>
+
+		            </xs:complexType>
+
+	           </xs:element>
+
+	           <xs:element name="FWTAuditHeadersRequest">
+
+	               <xs:complexType>
+
+	                    <xs:annotation>
+
+	                         <xs:documentation>
+Audit Header request      </xs:documentation>
+
+	                    </xs:annotation>
+
+	                    <xs:sequence>
+
+	                         <xs:element maxOccurs="1" minOccurs="0" name="UserId" nillable="true" type="xs:string"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="0" name="IpAddress" nillable="true" type="xs:string"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="0" name="StartDate" nillable="true" type="xs:date"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="0" name="EndDate" nillable="true" type="xs:date"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="0" name="Channel" nillable="true" type="xs:string"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="0" name="DomainArea" nillable="true" type="xs:string"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="0" name="OperationType" nillable="true" type="xs:string"/>
+
+	                         <xs:element maxOccurs="1" minOccurs="0" name="ObjectId" nillable="true" type="xs:string"/>
+
+	                    </xs:sequence>
+
+	               </xs:complexType>
+
+	       	    </xs:element>
+
+	       	    <xs:element name="FWTAuditHeadersResponse" nillable="true">
+
+	               <xs:complexType>
+
+	                    <xs:sequence>
+
+	                         <xs:element maxOccurs="100" minOccurs="0" ref="FWTAuditHeadersResponseItem"/>
+
+	                    </xs:sequence>
+
+	               </xs:complexType>
+
+	           </xs:element>
+
+	           <xs:element name="FWTAuditHeadersResponseItem" nillable="true">
+
+	               <xs:complexType>
+
+	                    <xs:annotation>
+
+	                         <xs:documentation>
+Audit header      </xs:documentation>
+
+	                    </xs:annotation>
+
+	                    <xs:sequence>
+
+	               <!-- ITEMID	USERID	AUDITDATE	IPADDRESS	CHANNEL	OBJECTID	DOMAINAREA	OPERATIONTYPE -->
+
+	                         <xs:element name="ItemId" type="xs:long"/>
+
+	                         <xs:element name="UserId" type="xs:string"/>
+
+	                         <xs:element name="AuditDate" type="xs:date"/>
+
+	                         <xs:element name="IpAddress" type="xs:string"/>
+
+	                         <xs:element name="Channel" type="xs:string"/>
+
+	                         <xs:element name="ObjectId" nillable="true" type="xs:string"/>
+
+	                         <xs:element name="DomainArea" type="xs:string"/>
+
+	                         <xs:element name="OperationType" type="xs:string"/>
+
+	                    </xs:sequence>
+
+	               </xs:complexType>
+
+	       	    </xs:element>
+
+	       	    <xs:element name="FWTItemId" nillable="true">
+
+	        	    <xs:simpleType>
+
+	        		     <xs:restriction base="xs:long"/>
+
+	        	    </xs:simpleType>
+
+	           </xs:element>
+
+
+	           <xs:element name="FWTAuditDetailResponse" nillable="true">
+
+	               <xs:complexType>
+
+	                    <xs:annotation>
+
+	                         <xs:documentation>
+Audit Details including header      </xs:documentation>
+
+	                    </xs:annotation>
+
+	                    <xs:sequence>
+
+	               <!-- ITEMID	USERID	AUDITDATE	IPADDRESS	CHANNEL	OBJECTID	DOMAINAREA	OPERATIONTYPE -->
+
+	                         <xs:element name="ItemId" type="xs:long"/>
+
+	                         <xs:element name="UserId" type="xs:string"/>
+
+	                         <xs:element name="AuditDate" type="xs:date"/>
+
+	                         <xs:element name="IpAddress" type="xs:string"/>
+
+	                         <xs:element name="Channel" type="xs:string"/>
+
+	                         <xs:element name="ObjectId" nillable="true" type="xs:string"/>
+
+	                         <xs:element name="DomainArea" type="xs:string"/>
+
+	                         <xs:element name="OperationType" type="xs:string"/>
+
+	                         <xs:element name="Inputs" type="xs:string"/>
+
+	                         <xs:element name="Outputs" type="xs:string"/>
+
+	                    </xs:sequence>
+
+	               </xs:complexType>
+
+	       	    </xs:element>
+
+
+          </xs:schema>
+
+     </wsdl:types>
+
+
+    <!--*********************************************************************************-->
+
+    <!--  WSDL MESSAGES  -->
+
+    <!--*********************************************************************************-->
+
+
+    <!--  LinkCases  -->
+
+     <wsdl:message name="linkCasesRequest">
+
+          <wsdl:part element="flt:FLLinkCasesParams" name="LinkCasesParams"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="linkCasesResponse">
+
+		  <wsdl:part element="flt:FLLinkCasesParamsResponse" name="LinkCasesRequestStatus"/>
+
+	 </wsdl:message>
+
+
+     <wsdl:message name="unLinkCasesRequest">
+
+          <wsdl:part element="flt:FLUnLinkCasesParams" name="UnLinkCasesParams"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="unLinkCasesResponse">
+
+		  <wsdl:part element="flt:FLUnLinkCasesParamsResponse" name="UnLinkCasesRequestStatus"/>
+
+	 </wsdl:message>
+
+
+    <!--  Cases and interactions -->
+
+     <wsdl:message name="retrieveMyCases"/>
+
+     <wsdl:message name="retrieveMyCasesResponse">
+
+          <wsdl:part element="flt:FWTCaseCoreDetailsList" name="MyCasesList"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="addToMyCases">
+
+          <wsdl:part element="flt:FLAddCaseList" name="AddCaseList"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="addToMyCasesResponse">
+
+		  <wsdl:part element="flt:FLAddCaseListResponse" name="AddToMyCasesStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="removeFromMyCases">
+
+          <wsdl:part element="flt:FLRemoveCaseList" name="RemoveCaseList"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="removeFromMyCasesResponse">
+
+		  <wsdl:part element="flt:FLRemoveCaseListResponse" name="RemoveFromMyCasesStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="deleteCases">
+
+          <wsdl:part element="flt:FLDeleteCaseList" name="CaseDelete"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="deleteCasesResponse">
+
+ 		  <wsdl:part element="flt:FLDeleteCaseListResponse" name="DeleteCasesStatus"/>
+
+ 	 </wsdl:message>
+
+     <wsdl:message name="searchForCases">
+
+          <wsdl:part element="flt:FWTCaseSearch" name="CaseSearch"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchForCasesResponse">
+
+          <wsdl:part element="flt:FWTCaseBriefDetailsList" name="MatchedCaseList"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchCaseDetails">
+
+          <wsdl:part element="flt:FWTSearchCaseDetailsRequest" name="searchCaseDetailsRequest"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchCaseDetailsResponse">
+
+          <wsdl:part element="flt:FWTSearchCaseDetailsResult" name="searchCaseDetailsResponse"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchTaskDetails">
+
+          <wsdl:part element="flt:FWTSearchTaskDetailsRequest" name="searchTaskDetailsRequest"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchTaskDetailsResponse">
+
+          <wsdl:part element="flt:FWTSearchTaskDetailsResult" name="searchTaskDetailsResponse"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchInteractionDetails">
+
+          <wsdl:part element="flt:FWTSearchInteractionDetailsRequest" name="searchInteractionDetailsRequest"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchInteractionDetailsResponse">
+
+          <wsdl:part element="flt:FWTSearchInteractionDetailsResult" name="searchInteractionDetailsResponse"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveCaseDetails">
+
+          <wsdl:part element="flt:FWTCaseFullDetailsRequest" name="CaseRetrieve"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveCaseDetailsResponse">
+
+          <wsdl:part element="flt:FWTCaseFullDetails" name="CaseFullDetails"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="addDocumentToRepository">
+
+          <wsdl:part element="flt:FWTDocument" name="RepositoryDocumentAdd"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="addDocumentToRepositoryResponse">
+
+          <wsdl:part element="flt:FWTDocumentRef" name="RepositoryDocumentAddRef"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createNotes">
+
+          <wsdl:part element="flt:FWTNoteToParentRef" name="NotesCreate"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="createNotesResponse">
+
+		  <wsdl:part element="flt:FWTNoteToParentRefResponse" name="CreateNotesStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="deleteNotes">
+
+          <wsdl:part element="flt:FWTNoteDetailDeleteRef" name="NotesDelete"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="updateNotes">
+
+          <wsdl:part element="flt:FWTNoteDetailUpdateRef" name="NotesUpdate"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="getNotes">
+
+          <wsdl:part element="flt:FWTNoteToParentGetRef" name="NotesGet"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="getNotesResponse">
+
+          <wsdl:part element="flt:FWTNoteDetailList" name="NotesGetRef"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="removeDocumentFromRepository">
+
+          <wsdl:part element="flt:FWTDocumentRemoveRef" name="RepositoryDocumentRemove"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="getDocumentFromRepository">
+
+          <wsdl:part element="flt:FWTDocumentGetRef" name="RepositoryDocumentGet"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="getDocumentFromRepositoryResponse">
+
+          <wsdl:part element="flt:FWTDocument" name="RepositoryDocumentGetRef"/>
+
+     </wsdl:message>
+
+       <wsdl:message name="searchAndRetrieveCaseDetailsRequest">
+
+          <wsdl:part element="flt:FWTSearchAndRetrieveCase" name="SearchAndRetrieveDetails"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchAndRetrieveCaseDetailsResponse">
+
+          <wsdl:part element="flt:FWTCaseFullDetailsList" name="CaseFullDetailsList"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createCase">
+
+          <wsdl:part element="flt:FWTCaseCreate" name="CaseCreate"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createCaseResponse">
+
+          <wsdl:part element="flt:CaseReference" name="CaseReference"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="updateCase">
+
+          <wsdl:part element="flt:FWTCaseUpdate" name="CaseUpdate"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="updateCaseResponse">
+
+		  <wsdl:part element="flt:FWTCaseUpdateResponse" name="UpdateCaseStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="calculateDueDateIn">
+
+          <wsdl:part element="flt:FWTCalculateDueDateInput" name="DueDateCalculateInput"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="calculateDueDateResponse">
+
+          <wsdl:part element="flt:FWTCalculateDueDateFinish" name="DueDateCalculateFinish"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="finishCases">
+
+          <wsdl:part element="flt:FWTCaseFinish" name="CaseFinish"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="finishCasesResponse">
+
+		  <wsdl:part element="flt:FWTCaseFinishResponse" name="FinishCasesStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="closeCases">
+
+          <wsdl:part element="flt:FWTCaseClose" name="CaseClose"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="closeCasesResponse">
+
+		  <wsdl:part element="flt:FWTCaseCloseResponse" name="CloseCasesStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="addCaseEvent">
+
+          <wsdl:part element="flt:FWTCaseEventNew" name="CaseEventNew"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="addCaseEventResponse">
+
+		  <wsdl:part element="flt:FWTCaseEventNewResponse" name="AddCaseEventStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="createCaseTask">
+
+          <wsdl:part element="flt:FWTCaseTaskNew" name="CaseTaskNew"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createCaseTaskResponse">
+
+          <wsdl:part element="flt:TaskID" name="TaskID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="updateCaseTask">
+
+          <wsdl:part element="flt:FWTCaseTaskUpdate" name="CaseTaskUpdate"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="updateCaseTaskResponse">
+
+		  <wsdl:part element="flt:FWTCaseTaskUpdateResponse" name="UpdateCaseTaskStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="addCaseEform">
+
+          <wsdl:part element="flt:FWTCaseEformNew" name="CaseEformNew"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="addCaseEformResponse">
+
+		  <wsdl:part element="flt:FWTCaseEformNewResponse" name="AddCaseEformStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="createInteraction">
+
+          <wsdl:part element="flt:FWTInteractionCreate" name="InteractionCreate"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createInteractionResponse">
+
+          <wsdl:part element="flt:InteractionID" name="InteractionID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="updateInteraction">
+
+          <wsdl:part element="flt:FWTInteractionUpdate" name="InteractionUpdate"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="updateInteractionResponse">
+
+		  <wsdl:part element="flt:FWTInteractionUpdateResponse" name="UpdateInteractionStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="linkInteractionToCase">
+
+          <wsdl:part element="flt:FWTInteractionCaseLink" name="InteractionCaselink"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="linkInteractionToCaseResponse">
+
+		  <wsdl:part element="flt:FWTInteractionCaseLinkResponse" name="LinkInteractionToCaseStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="readCaseEformData">
+
+          <wsdl:part element="flt:FLCaseEformInstance" name="ReadCaseEform"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="readCaseEformDataResponse">
+
+          <wsdl:part element="flt:FLEformData" name="CaseEformdata"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="writeCaseEformData">
+          <wsdl:part element="flt:FLEformFields" name="WriteCaseEform"/>
+     </wsdl:message>
+
+	 <wsdl:message name="writeCaseEformDataResponse">
+
+		  <wsdl:part element="flt:FLEformFieldsResponse" name="WriteCaseEformDataStatus"/>
+
+	 </wsdl:message>
+
+
+    <!--  ODM  -->
+
+     <wsdl:message name="searchForParty">
+
+          <wsdl:part element="flt:FWTPartySearch" name="PartySearch"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchForPartyResponse">
+
+          <wsdl:part element="flt:FWTObjectBriefDetailsList" name="PartyList"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchForProperty">
+
+          <wsdl:part element="flt:FWTPropertySearch" name="PropertySearch"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchForPropertyResponse">
+
+          <wsdl:part element="flt:FWTObjectBriefDetailsList" name="PropertyList"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchForStreet">
+
+          <wsdl:part element="flt:FWTStreetSearch" name="StreetSearch"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchForStreetResponse">
+
+          <wsdl:part element="flt:FWTObjectBriefDetailsList" name="StreetList"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveIndividual">
+
+          <wsdl:part element="flt:FLIndividualID" name="IndividualID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveIndividualResponse">
+
+          <wsdl:part element="flt:FWTIndividual" name="Individual"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveOrganisation">
+
+          <wsdl:part element="flt:FLOrganisationID" name="OrganisationID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveOrganisationResponse">
+
+          <wsdl:part element="flt:FWTOrganisation" name="Organisation"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveProperty">
+
+          <wsdl:part element="flt:FLPropertyID" name="PropertyID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrievePropertyResponse">
+
+          <wsdl:part element="flt:FWTProperty" name="Property"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveStreet">
+
+          <wsdl:part element="flt:FLStreetID" name="StreetID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveStreetResponse">
+
+          <wsdl:part element="flt:FWTStreet" name="Street"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createIndividual">
+
+          <wsdl:part element="flt:FWTIndividual" name="IndividualCreate"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createIndividualResponse">
+
+          <wsdl:part element="flt:FLNewIndividualID" name="IndividualCreateResponse"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createOrganisation">
+
+          <wsdl:part element="flt:FWTOrganisation" name="OrganisationCreate"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createOrganisationResponse">
+
+          <wsdl:part element="flt:FLNewOrganisationID" name="OrganisationCreateResponse"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="updateIndividual">
+
+          <wsdl:part element="flt:FWTIndividualUpdate" name="IndividualUpdate"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="updateIndividualResponse">
+
+		  <wsdl:part element="flt:FWTIndividualUpdateResponse" name="UpdateIndividualStatus"/>
+
+	 </wsdl:message>
+
+	 <wsdl:message name="updateOrganisationResponse">
+
+		  <wsdl:part element="flt:FWTOrganisationUpdateResponse" name="UpdateOrganisationStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="updateOrganisation">
+
+          <wsdl:part element="flt:FWTOrganisationUpdate" name="OrganisationUpdate"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createPartyMerge">
+
+          <wsdl:part element="flt:FWTMergeCreate" name="MergeCreate"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createPartyMergeResponse">
+
+          <wsdl:part element="flt:MergeID" name="MergeID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="deleteParty">
+
+          <wsdl:part element="flt:FLDeletePartyID" name="PartyDelete"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="deletePartyResponse">
+
+		  <wsdl:part element="flt:FLDeletePartyIDResponse" name="DeletePartyStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="rollbackPartyMerge">
+
+          <wsdl:part element="flt:FLRollbackMerge" name="RollbackMerge"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="rollbackPartyMergeResponse">
+
+		  <wsdl:part element="flt:FLRollbackMergeResponse" name="RollbackPartyMergeStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="deleteRelationship">
+
+          <wsdl:part element="flt:FLDeleteRelationshipID" name="RelationshipDelete"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="deleteRelationshipResponse">
+
+		  <wsdl:part element="flt:FLDeleteRelationshipIDResponse" name="DeleteRelationshipStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="retrieveRelationship">
+
+          <wsdl:part element="flt:FLRetrieveRelationshipID" name="RelationshipRetrieve"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="updatePartyCluster">
+
+          <wsdl:part element="flt:FLPartyCluster" name="UpdateCluster"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="updatePartyClusterResponse">
+
+		  <wsdl:part element="flt:FLPartyClusterResponse" name="UpdatePartyClusterStatus"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="clearPartyCluster">
+
+          <wsdl:part element="flt:FLObjectIdList" name="ClearCluster"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="clearPartyClusterResponse">
+
+		  <wsdl:part element="flt:FLObjectIdListResponse" name="ClearPartyCluster"/>
+
+	 </wsdl:message>
+
+     <wsdl:message name="retrieveRelationships">
+
+          <wsdl:part element="flt:FLRelationshipPartyID" name="RelationshipOwner"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveRelationshipsResponse">
+
+          <wsdl:part element="flt:FWTRelationshipList" name="RelationshipList"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveRelationshipResponse">
+
+          <wsdl:part element="flt:FLRetreiveRelationship" name="Relationship"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createRelationship">
+
+          <wsdl:part element="flt:FLRelationshipCreate" name="RelationshipCreate"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createRelationshipResponse">
+
+          <wsdl:part element="flt:FLNewRelationshipID" name="NewRelationshipID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="updateRelationshipTimeframe">
+
+          <wsdl:part element="flt:FLRelationshipTimeframeUpdate" name="RelationshipTimeframeUpdate"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="updateRelationshipFormData">
+
+          <wsdl:part element="flt:FLRelationshipFormDataUpdate" name="RelationshipFormDataUpdate"/>
+
+     </wsdl:message>
+
+
+    <!--  Messaging  -->
+
+     <wsdl:message name="retrieveGeneralMessages">
+
+          <wsdl:part element="flt:MessageAgeLimit" name="MessageAgeLimit"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveGeneralMessagesResponse">
+
+          <wsdl:part element="flt:FWTMessageGeneralList" name="GeneralMessageList"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrievePartyMessages">
+
+          <wsdl:part element="flt:FLPartyID" name="PartyID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrievePartyMessagesResponse">
+
+          <wsdl:part element="flt:FWTMessagePartyList" name="PartyMessageList"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createGeneralMessage">
+
+          <wsdl:part element="flt:FWTMessageGeneralNew" name="GeneralMessage"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createGeneralMessageResponse">
+
+          <wsdl:part element="flt:GeneralMessageID" name="GeneralMessageID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createPartyMessage">
+
+          <wsdl:part element="flt:FWTMessagePartyNew" name="PartyMessage"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createPartyMessageResponse">
+
+          <wsdl:part element="flt:PartyMessageID" name="PartyMessageID"/>
+
+     </wsdl:message>
+
+
+    <!-- Events -->
+
+     <wsdl:message name="retrieveEvents">
+
+          <wsdl:part element="flt:FWTEventType" name="EventType"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveEventsResponse">
+
+          <wsdl:part element="flt:FWTEventList" name="EventList"/>
+
+     </wsdl:message>
+
+
+    <!--  Exceptions  -->
+
+     <wsdl:message name="serviceException">
+
+          <wsdl:part element="flt:FWTException" name="FLException"/>
+
+     </wsdl:message>
+
+
+    <!--  WP26 3.1 retrieveExtensionParty -->
+
+     <wsdl:message name="retrieveExtensionParty">
+
+          <wsdl:part element="flt:FLExtensionPartyID" name="PartyID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveExtensionPartyResponse">
+
+          <wsdl:part element="flt:FLExtensionParty" name="Party"/>
+
+     </wsdl:message>
+
+
+    <!--  WP26 3.2 retrieveExtensionObject -->
+
+     <wsdl:message name="retrieveExtensionObject">
+
+          <wsdl:part element="flt:FLExtensionObjectID" name="ObjectID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveExtensionObjectResponse">
+
+          <wsdl:part element="flt:FLExtensionObject" name="Object"/>
+
+     </wsdl:message>
+
+
+    <!--  WP26 3.7 searchForObject -->
+
+     <wsdl:message name="searchForObject">
+
+          <wsdl:part element="flt:FWTObjectSearchCriteria" name="ObjectSearch"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchForObjectResponse">
+
+          <wsdl:part element="flt:FWTObjectBriefDetailsList" name="ObjectList"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="createExtensionObject">
+
+          <wsdl:part element="flt:FLExtensionObjectCreate" name="ExtObject"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createExtensionObjectResponse">
+
+          <wsdl:part element="flt:FLNewExtensionObjectID" name="ObjectID"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="createExtensionParty">
+
+          <wsdl:part element="flt:FLExtensionPartyCreate" name="ExtObject"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createExtensionPartyResponse">
+
+          <wsdl:part element="flt:FLNewExtensionPartyID" name="ObjectID"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="updateExtensionObject">
+
+          <wsdl:part element="flt:FLExtensionObjectUpdate" name="ExtObject"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="updateExtensionObjectResponse">
+
+		  <wsdl:part element="flt:FLExtensionObjectUpdateResponse" name="UpdateExtensionObjectStatus"/>
+
+	 </wsdl:message>
+
+
+     <wsdl:message name="updateExtensionParty">
+
+          <wsdl:part element="flt:FLExtensionPartyUpdate" name="ExtObject"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="updateExtensionPartyResponse">
+
+		  <wsdl:part element="flt:FLExtensionPartyUpdateResponse" name="UpdateExtensionPartyStatus"/>
+
+	 </wsdl:message>
+
+
+     <wsdl:message name="invokeRuleEngine">
+
+          <wsdl:part element="flt:FWTRuleEngineCriteria" name="RuleEngineCriteria"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="invokeRuleEngineResponse">
+
+          <wsdl:part element="flt:FWTRuleEngineResults" name="RuleEngineResults"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="retrieveCodeValue">
+
+          <wsdl:part element="flt:CodeKey" name="CodeKey"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveCodeValueResponse">
+
+          <wsdl:part element="flt:CodeValue" name="CodeValue"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="retrieveCodeBook">
+
+          <wsdl:part element="flt:CodeBookName" name="CodeBookName"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveCodeBookResponse">
+
+          <wsdl:part element="flt:FWTCodeBook" name="CodeBook"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="getAcl">
+
+          <wsdl:part element="flt:DomainObjectID" name="DomainObject"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="getAclResponse">
+
+          <wsdl:part element="flt:FWTSidAccessPermissionsList" name="SidPermisionsList"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="setAcl">
+
+          <wsdl:part element="flt:FWTSetAcl" name="setAcl"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="setSidAccessPermissions">
+
+          <wsdl:part element="flt:FWTSetSidAccessPermissions" name="SetSidAccessPermissions"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="insertSidAccessPermissions">
+
+          <wsdl:part element="flt:FWTInsertSidAccessPermissions" name="InsertSidAccessPermissions"/>
+
+     </wsdl:message>
+
+
+     <wsdl:message name="removeSidAccessPermissions">
+
+          <wsdl:part element="flt:FWTRemoveSidAccessPermissions" name="RemoveSidAccessPermissions"/>
+
+     </wsdl:message>
+
+
+    <!-- Lucene Search -->
+
+     <wsdl:message name="search">
+
+          <wsdl:part element="flt:FWTSearchCriteria" name="SearchCriteria"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="searchResponse">
+
+          <wsdl:part element="flt:FWTSearchResult" name="SearchResult"/>
+
+     </wsdl:message>
+
+
+    <!-- Face To Face -->
+
+     <wsdl:message name="createFaceToFaceHeader">
+
+          <wsdl:part element="flt:FWTFaceToFaceHeader" name="FaceToFaceHeader"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createFaceToFaceHeaderResponse">
+
+          <wsdl:part element="flt:FWTFaceToFaceID" name="FaceToFaceID"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="createFaceToFaceConversation">
+
+          <wsdl:part element="flt:FWTFaceToFaceConversation" name="FaceToFaceConversationInteraction"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="createFaceToFaceConversationResponse">
+
+		  <wsdl:part element="flt:FWTFaceToFaceConversationResponse" name="CreateFaceToFaceConversationStatus"/>
+
+	 </wsdl:message>
+
+
+     <wsdl:message name="reopenCaseRequest">
+
+          <wsdl:part element="flt:FWTReopenCaseRequest" name="reopenCaseRequest"/>
+
+     </wsdl:message>
+
+	 <wsdl:message name="reopenCaseRequestResponse">
+
+		  <wsdl:part element="flt:FWTReopenCaseRequestResponse" name="ReopenCaseRequestStatus"/>
+
+	 </wsdl:message>
+
+	<!--  Audit Services -->
+
+     <wsdl:message name="updateAuditMethodRequest">
+
+          <wsdl:part element="flt:FWTAuditMethodDescriptor" name="updateAuditMethodRequest"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="updateAuditMethodResponse">
+
+          <wsdl:part element="flt:FWTUpdateAuditMethodResponse" name="updateAuditMethodResponse"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveAuditableServiceNames">
+
+    	  <wsdl:part element="flt:FWTAuditableServiceNamesRequest" name="retrieveAuditableServiceNames"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveAuditableServiceResponse">
+
+          <wsdl:part element="flt:FWTAuditableServiceNamesList" name="retrieveAuditableServiceResponse"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveAuditableOperationsRequest">
+
+          <wsdl:part element="flt:FWTAuditableServiceOperationsRequest" name="retrieveAuditableOperationsRequest"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveAuditableOperationsResponse">
+
+          <wsdl:part element="flt:FWTAuditableServiceOperationsList" name="retrieveAuditableOperationsResponse"/>
+
+     </wsdl:message>
+
+    <!--  -->
+
+     <wsdl:message name="retrieveAuditHeadersRequest">
+
+    	  <wsdl:part element="flt:FWTAuditHeadersRequest" name="retrieveAuditHeadersRequest"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveAuditHeadersResponse">
+
+          <wsdl:part element="flt:FWTAuditHeadersResponse" name="retrieveAuditHeadersResponse"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveAuditDetailRequest">
+
+          <wsdl:part element="flt:FWTItemId" name="retrieveAuditDetailRequest"/>
+
+     </wsdl:message>
+
+     <wsdl:message name="retrieveAuditDetailResponse">
+
+          <wsdl:part element="flt:FWTAuditDetailResponse" name="retrieveAuditDetailResponse"/>
+
+     </wsdl:message>
+
+
+    <!--*********************************************************************************-->
+
+    <!--  WSDL PORTTYPE  -->
+
+    <!--*********************************************************************************-->
+
+     <wsdl:portType name="FLWebInterface">
+
+
+        <!--  LinkCases  -->
+
+          <wsdl:operation name="linkCases">
+
+               <wsdl:input message="fls:linkCasesRequest"/>
+
+			   <wsdl:output message="fls:linkCasesResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="unLinkCases">
+
+               <wsdl:input message="fls:unLinkCasesRequest"/>
+
+			   <wsdl:output message="fls:unLinkCasesResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+        <!--  Cases and interactions -->
+
+          <wsdl:operation name="retrieveMyCases">
+
+               <wsdl:documentation>
+
+                Retrieves core details of cases owned by the caller
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveMyCases"/>
+
+               <wsdl:output message="fls:retrieveMyCasesResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="addToMyCases">
+
+               <wsdl:documentation>
+
+                Gives ownership of one or more cases to the caller
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:addToMyCases"/>
+
+			   <wsdl:output message="fls:addToMyCasesResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="removeFromMyCases">
+
+               <wsdl:documentation>
+
+                Removes ownership of one or more cases from the caller
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:removeFromMyCases"/>
+
+			   <wsdl:output message="fls:removeFromMyCasesResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="deleteCases">
+
+               <wsdl:documentation>
+Delete a case   </wsdl:documentation>
+
+               <wsdl:input message="fls:deleteCases"/>
+
+ 			   <wsdl:output message="fls:deleteCasesResponse"/>
+
+ 			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+ 		  </wsdl:operation>
+
+          <wsdl:operation name="searchForCases">
+
+               <wsdl:documentation>
+
+                Retrieves brief details of cases matching the given
+                search criteria
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:searchForCases"/>
+
+               <wsdl:output message="fls:searchForCasesResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchCaseDetails">
+
+               <wsdl:documentation>
+
+                Searches for case details
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:searchCaseDetails"/>
+
+               <wsdl:output message="fls:searchCaseDetailsResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchTaskDetails">
+
+               <wsdl:documentation>
+
+                Searches for task details
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:searchTaskDetails"/>
+
+               <wsdl:output message="fls:searchTaskDetailsResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchInteractionDetails">
+
+               <wsdl:documentation>
+
+                Searches for interaction details
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:searchInteractionDetails"/>
+
+               <wsdl:output message="fls:searchInteractionDetailsResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveCaseDetails">
+
+               <wsdl:documentation>
+
+                Retrieves full details of a case
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveCaseDetails"/>
+
+               <wsdl:output message="fls:retrieveCaseDetailsResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="addDocumentToRepository">
+
+               <wsdl:documentation>
+
+                adds a document to the Lagan Repository
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:addDocumentToRepository"/>
+
+               <wsdl:output message="fls:addDocumentToRepositoryResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="removeDocumentFromRepository">
+
+               <wsdl:documentation>
+
+                removes a document from the Lagan Repository
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:removeDocumentFromRepository"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="getDocumentFromRepository">
+
+               <wsdl:documentation>
+
+                gets a document from the Lagan Repository
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:getDocumentFromRepository"/>
+
+               <wsdl:output message="fls:getDocumentFromRepositoryResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createNotes">
+
+               <wsdl:documentation>
+
+                attaches a note to a case or interaction
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createNotes"/>
+
+			   <wsdl:output message="fls:createNotesResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="deleteNotes">
+
+               <wsdl:documentation>
+
+                deletes a note from a case or interaction
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:deleteNotes"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateNotes">
+
+               <wsdl:documentation>
+
+                updates a note in a case or interaction
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:updateNotes"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="getNotes">
+
+               <wsdl:documentation>
+
+                updates a note in a case or interaction
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:getNotes"/>
+
+               <wsdl:output message="fls:getNotesResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createCase">
+
+               <wsdl:documentation>
+
+                Creates a case and optionally links it to an interaction
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createCase"/>
+
+               <wsdl:output message="fls:createCaseResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateCase">
+
+               <wsdl:documentation>
+Updates a case   </wsdl:documentation>
+
+               <wsdl:input message="fls:updateCase"/>
+
+			   <wsdl:output message="fls:updateCaseResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="calculateDueDate">
+
+               <wsdl:documentation>
+
+                Calculate Working Days For a given SLA value (D5, D10...)
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:calculateDueDateIn"/>
+
+               <wsdl:output message="fls:calculateDueDateResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="finishCases">
+
+               <wsdl:documentation>
+
+                Finishes one or more cases; reschedule, reallocate, or
+                complete workflow step; ownership is relinquished
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:finishCases"/>
+
+			   <wsdl:output message="fls:finishCasesResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="closeCases">
+
+               <wsdl:documentation>
+
+                Closes one or more cases
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:closeCases"/>
+
+			   <wsdl:output message="fls:closeCasesResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="addCaseEvent">
+
+               <wsdl:documentation>
+
+                Adds an event to a case
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:addCaseEvent"/>
+
+			   <wsdl:output message="fls:addCaseEventResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createCaseTask">
+
+               <wsdl:documentation>
+
+                Creates a task for a case; the task can be predefined or
+                manually defined
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createCaseTask"/>
+
+               <wsdl:output message="fls:createCaseTaskResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateCaseTask">
+
+               <wsdl:documentation>
+Updates a case task   </wsdl:documentation>
+
+               <wsdl:input message="fls:updateCaseTask"/>
+
+			   <wsdl:output message="fls:updateCaseTaskResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="addCaseEform">
+
+               <wsdl:documentation>
+
+                Adds an eform to a case. Note that the parameter EformName is referring to
+                the name of the eForm definition NOT the name of the eForm.
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:addCaseEform"/>
+
+			   <wsdl:output message="fls:addCaseEformResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createInteraction">
+
+               <wsdl:documentation>
+
+                Creates an interaction and optionally links it to a case
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createInteraction"/>
+
+               <wsdl:output message="fls:createInteractionResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateInteraction">
+
+               <wsdl:documentation>
+
+                Creates an interaction and optionally links it to a case
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:updateInteraction"/>
+
+			   <wsdl:output message="fls:updateInteractionResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="linkInteractionToCase">
+
+               <wsdl:documentation>
+
+                Links an interaction to a case
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:linkInteractionToCase"/>
+
+			   <wsdl:output message="fls:linkInteractionToCaseResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="writeCaseEformData">
+
+               <wsdl:documentation>
+
+                Stores data coming from an EForm object
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:writeCaseEformData"/>
+
+			   <wsdl:output message="fls:writeCaseEformDataResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="readCaseEformData">
+
+               <wsdl:documentation>
+
+                Reads data from an EForm object
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:readCaseEformData"/>
+
+               <wsdl:output message="fls:readCaseEformDataResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+        <!--  ODM  -->
+
+          <wsdl:operation name="searchForParty">
+
+               <wsdl:documentation>
+
+                Retrieves brief details of individuals or organisations
+                matching the given search criteria
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:searchForParty"/>
+
+               <wsdl:output message="fls:searchForPartyResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchForProperty">
+
+               <wsdl:documentation>
+
+                Retrieves brief details of properties matching the given
+                search criteria
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:searchForProperty"/>
+
+               <wsdl:output message="fls:searchForPropertyResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchForStreet">
+
+               <wsdl:documentation>
+
+                Retrieves brief details of streets matching the given
+                search criteria
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:searchForStreet"/>
+
+               <wsdl:output message="fls:searchForStreetResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveIndividual">
+
+               <wsdl:documentation>
+
+                Retrieves full details of an individual
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveIndividual"/>
+
+               <wsdl:output message="fls:retrieveIndividualResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveOrganisation">
+
+               <wsdl:documentation>
+
+                Retrieves full details of an organisation
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveOrganisation"/>
+
+               <wsdl:output message="fls:retrieveOrganisationResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveProperty">
+
+               <wsdl:documentation>
+
+                Retrieves full details of a property
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveProperty"/>
+
+               <wsdl:output message="fls:retrievePropertyResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveStreet">
+
+               <wsdl:documentation>
+
+                Retrieves full details of a street
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveStreet"/>
+
+               <wsdl:output message="fls:retrieveStreetResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createIndividual">
+
+               <wsdl:documentation>
+
+                Creates an individual and merges parties behind the
+                created record when a list of party Ids is provided
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createIndividual"/>
+
+               <wsdl:output message="fls:createIndividualResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createOrganisation">
+
+               <wsdl:documentation>
+
+                Creates an organisation
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createOrganisation"/>
+
+               <wsdl:output message="fls:createOrganisationResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateIndividual">
+
+               <wsdl:documentation>
+
+                Updates an individual
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:updateIndividual"/>
+
+			   <wsdl:output message="fls:updateIndividualResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateOrganisation">
+
+               <wsdl:documentation>
+
+                Updates an organisation
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:updateOrganisation"/>
+
+			   <wsdl:output message="fls:updateOrganisationResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createPartyMerge">
+
+               <wsdl:documentation>
+
+                Merges a list of parties into the target party
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createPartyMerge"/>
+
+               <wsdl:output message="fls:createPartyMergeResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="deleteParty">
+
+               <wsdl:documentation>
+Deletes a party   </wsdl:documentation>
+
+               <wsdl:input message="fls:deleteParty"/>
+
+			   <wsdl:output message="fls:deletePartyResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="rollbackPartyMerge">
+
+               <wsdl:documentation>
+
+                Dissolves the merge process performed on the party.
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:rollbackPartyMerge"/>
+
+			   <wsdl:output message="fls:rollbackPartyMergeResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updatePartyCluster">
+
+               <wsdl:documentation>
+
+                Updates the cluster Ids of the parties in the list.
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:updatePartyCluster"/>
+
+			   <wsdl:output message="fls:updatePartyClusterResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="clearPartyCluster">
+
+               <wsdl:documentation>
+
+                Clears the cluster Ids of the parties in the list.
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:clearPartyCluster"/>
+
+			   <wsdl:output message="fls:clearPartyClusterResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createRelationship">
+
+               <wsdl:documentation>
+
+                Creates a new relationship instance
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createRelationship"/>
+
+               <wsdl:output message="fls:createRelationshipResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="deleteRelationship">
+
+               <wsdl:documentation>
+
+                Deletes a relationship
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:deleteRelationship"/>
+
+			   <wsdl:output message="fls:deleteRelationshipResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveRelationship">
+
+               <wsdl:documentation>
+
+                Retrieves a relationship record given the relationship Id
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveRelationship"/>
+
+               <wsdl:output message="fls:retrieveRelationshipResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveRelationships">
+
+               <wsdl:documentation>
+
+                Retrieves an object's relationships
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveRelationships"/>
+
+               <wsdl:output message="fls:retrieveRelationshipsResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateRelationshipTimeframe">
+
+               <wsdl:documentation>
+
+                Updates a relationship's dates
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:updateRelationshipTimeframe"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateRelationshipFormData">
+
+               <wsdl:documentation>
+
+                Updates a relationship's form data
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:updateRelationshipFormData"/>
+
+          </wsdl:operation>
+
+
+        <!--  Messaging  -->
+
+          <wsdl:operation name="retrieveGeneralMessages">
+
+               <wsdl:documentation>
+
+                Retrieves general messages
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveGeneralMessages"/>
+
+               <wsdl:output message="fls:retrieveGeneralMessagesResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrievePartyMessages">
+
+               <wsdl:documentation>
+
+                Retrieves party messages
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrievePartyMessages"/>
+
+               <wsdl:output message="fls:retrievePartyMessagesResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createGeneralMessage">
+
+               <wsdl:documentation>
+
+                Creates a general message
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createGeneralMessage"/>
+
+               <wsdl:output message="fls:createGeneralMessageResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createPartyMessage">
+
+               <wsdl:documentation>
+
+                Creates a party message
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:createPartyMessage"/>
+
+               <wsdl:output message="fls:createPartyMessageResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+        <!-- Events -->
+
+          <wsdl:operation name="retrieveEvents">
+
+               <wsdl:documentation>
+
+                Retrieves details on all events of the specified type
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveEvents"/>
+
+               <wsdl:output message="fls:retrieveEventsResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+        <!--  WP26 3.1 retrieveExtensionParty -->
+
+          <wsdl:operation name="retrieveExtensionParty">
+
+               <wsdl:documentation>
+
+                Retrieves an Extension Party
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveExtensionParty"/>
+
+               <wsdl:output message="fls:retrieveExtensionPartyResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+        <!--  WP26 3.2 retrieveExtensionObject -->
+
+          <wsdl:operation name="retrieveExtensionObject">
+
+               <wsdl:documentation>
+
+                Retrieves an Extension Object
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveExtensionObject"/>
+
+               <wsdl:output message="fls:retrieveExtensionObjectResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+        <!--  WP26 3.7 searchForObject -->
+
+          <wsdl:operation name="searchForObject">
+
+               <wsdl:documentation>
+Searches object   </wsdl:documentation>
+
+               <wsdl:input message="fls:searchForObject"/>
+
+               <wsdl:output message="fls:searchForObjectResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+          <wsdl:operation name="createExtensionObject">
+
+               <wsdl:documentation>
+Creates an extension object   </wsdl:documentation>
+
+               <wsdl:input message="fls:createExtensionObject"/>
+
+               <wsdl:output message="fls:createExtensionObjectResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+          <wsdl:operation name="createExtensionParty">
+
+               <wsdl:documentation>
+Creates an extension party   </wsdl:documentation>
+
+               <wsdl:input message="fls:createExtensionParty"/>
+
+               <wsdl:output message="fls:createExtensionPartyResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+          <wsdl:operation name="updateExtensionObject">
+
+               <wsdl:documentation>
+Updates an extension object   </wsdl:documentation>
+
+               <wsdl:input message="fls:updateExtensionObject"/>
+
+			   <wsdl:output message="fls:updateExtensionObjectResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+          <wsdl:operation name="updateExtensionParty">
+
+               <wsdl:documentation>
+Updates an extension party   </wsdl:documentation>
+
+               <wsdl:input message="fls:updateExtensionParty"/>
+
+			   <wsdl:output message="fls:updateExtensionPartyResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="invokeRuleEngine">
+
+			   <wsdl:documentation>
+This operation is not used and is no longer available   </wsdl:documentation>
+
+               <wsdl:input message="fls:invokeRuleEngine"/>
+
+               <wsdl:output message="fls:invokeRuleEngineResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveCodeValue">
+
+               <wsdl:documentation>
+Retrieves a code value   </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveCodeValue"/>
+
+               <wsdl:output message="fls:retrieveCodeValueResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveCodeBook">
+
+               <wsdl:documentation>
+Retrieves a code book   </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveCodeBook"/>
+
+               <wsdl:output message="fls:retrieveCodeBookResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchAndRetrieveCaseDetails">
+
+               <wsdl:documentation>
+
+                Search and Retrieves full details of a case
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:searchAndRetrieveCaseDetailsRequest"/>
+
+               <wsdl:output message="fls:searchAndRetrieveCaseDetailsResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="getAcl">
+
+               <wsdl:documentation>
+
+                Retrieves list of Sid Access Permissions
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:getAcl"/>
+
+               <wsdl:output message="fls:getAclResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="setAcl">
+
+               <wsdl:documentation>
+
+                Sets the Acl
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:setAcl"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="setSidAccessPermissions">
+
+               <wsdl:documentation>
+
+                Set the sid access permissions
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:setSidAccessPermissions"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="insertSidAccessPermissions">
+
+               <wsdl:documentation>
+
+                Insert a Sid access permissions
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:insertSidAccessPermissions"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="removeSidAccessPermissions">
+
+               <wsdl:documentation>
+
+                Remove a Sid access permissions
+               </wsdl:documentation>
+
+               <wsdl:input message="fls:removeSidAccessPermissions"/>
+
+          </wsdl:operation>
+
+        <!-- Lucene Search -->
+
+          <wsdl:operation name="search">
+
+               <wsdl:documentation>
+Perform a Lucene search   </wsdl:documentation>
+
+               <wsdl:input message="fls:search"/>
+
+               <wsdl:output message="fls:searchResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+
+        <!-- Face To Face -->
+
+          <wsdl:operation name="createFaceToFaceHeader">
+
+               <wsdl:documentation>
+Creates a face to face header record   </wsdl:documentation>
+
+               <wsdl:input message="fls:createFaceToFaceHeader"/>
+
+               <wsdl:output message="fls:createFaceToFaceHeaderResponse"/>
+
+               <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createFaceToFaceConversation">
+
+               <wsdl:documentation>
+Creates a face to face conversation   </wsdl:documentation>
+
+               <wsdl:input message="fls:createFaceToFaceConversation"/>
+
+			   <wsdl:output message="fls:createFaceToFaceConversationResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="reopenCase">
+
+               <wsdl:documentation>
+Reopening of case   </wsdl:documentation>
+
+               <wsdl:input message="fls:reopenCaseRequest"/>
+
+			   <wsdl:output message="fls:reopenCaseRequestResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+        <!--  Audit Services -->
+
+          <wsdl:operation name="updateAuditOperationStatus">
+
+               <wsdl:documentation>
+Update if method can be audited   </wsdl:documentation>
+
+               <wsdl:input message="fls:updateAuditMethodRequest"/>
+
+			   <wsdl:output message="fls:updateAuditMethodResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveAuditableServiceNames">
+
+               <wsdl:documentation>
+Returns a list of the names of all services which have operations
+             that can be audited   </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveAuditableServiceNames"/>
+
+               <wsdl:output message="fls:retrieveAuditableServiceResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveAuditableOperationsForService">
+
+               <wsdl:documentation>
+Update if method can be audited   </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveAuditableOperationsRequest"/>
+
+			   <wsdl:output message="fls:retrieveAuditableOperationsResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveAuditHeaders">
+
+               <wsdl:documentation>
+Allows a user to query audit records present in Audit Headers   </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveAuditHeadersRequest"/>
+
+			   <wsdl:output message="fls:retrieveAuditHeadersResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveAuditDetail">
+
+               <wsdl:documentation>
+Retrieves full details of the Audit record including headers   </wsdl:documentation>
+
+               <wsdl:input message="fls:retrieveAuditDetailRequest"/>
+
+			   <wsdl:output message="fls:retrieveAuditDetailResponse"/>
+
+			   <wsdl:fault message="fls:serviceException" name="serviceException"/>
+
+          </wsdl:operation>
+
+     </wsdl:portType>
+
+    <!--*********************************************************************************-->
+
+    <!--  WSDL BINDING  -->
+
+    <!--*********************************************************************************-->
+
+     <wsdl:binding name="FLWebBinding" type="fls:FLWebInterface">
+
+          <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+
+
+        <!--  LinkCases  -->
+
+          <wsdl:operation name="linkCases">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="unLinkCases">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+
+        <!--  Cases and interactions -->
+
+          <wsdl:operation name="retrieveMyCases">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="addToMyCases">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="removeFromMyCases">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="deleteCases">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchForCases">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchCaseDetails">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchTaskDetails">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchInteractionDetails">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveCaseDetails">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createNotes">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="deleteNotes">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateNotes">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="getNotes">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="addDocumentToRepository">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="removeDocumentFromRepository">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="getDocumentFromRepository">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createCase">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateCase">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="calculateDueDate">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="finishCases">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="closeCases">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="addCaseEvent">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createCaseTask">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateCaseTask">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="addCaseEform">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="writeCaseEformData">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="readCaseEformData">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createInteraction">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateInteraction">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="linkInteractionToCase">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+
+        <!--  ODM  -->
+
+          <wsdl:operation name="searchForParty">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchForProperty">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchForStreet">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveIndividual">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveOrganisation">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveProperty">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveStreet">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createIndividual">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createOrganisation">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateIndividual">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateOrganisation">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createPartyMerge">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="deleteParty">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="rollbackPartyMerge">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updatePartyCluster">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="clearPartyCluster">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createRelationship">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="deleteRelationship">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveRelationship">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveRelationships">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateRelationshipTimeframe">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="updateRelationshipFormData">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+          </wsdl:operation>
+
+
+        <!--  Messaging  -->
+
+          <wsdl:operation name="retrieveGeneralMessages">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrievePartyMessages">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createGeneralMessage">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createPartyMessage">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+
+        <!-- Events -->
+
+          <wsdl:operation name="retrieveEvents">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+
+        <!--  WP26 3.1 retrieveExtensionParty -->
+
+          <wsdl:operation name="retrieveExtensionParty">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+
+        <!--  WP26 3.2 retrieveExtensionObject -->
+
+          <wsdl:operation name="retrieveExtensionObject">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+
+        <!--  WP26 3.7 searchForObject -->
+
+          <wsdl:operation name="searchForObject">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+
+          <wsdl:operation name="createExtensionObject">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+
+          <wsdl:operation name="createExtensionParty">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+
+          <wsdl:operation name="updateExtensionObject">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+
+          <wsdl:operation name="updateExtensionParty">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="invokeRuleEngine">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveCodeValue">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveCodeBook">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="searchAndRetrieveCaseDetails">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="getAcl">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="setAcl">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="setSidAccessPermissions">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="insertSidAccessPermissions">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="removeSidAccessPermissions">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+          </wsdl:operation>
+
+        <!-- Lucene Search -->
+
+          <wsdl:operation name="search">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+
+          <wsdl:operation name="createFaceToFaceHeader">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:output>
+
+               <wsdl:fault name="serviceException">
+
+                    <soap:fault name="serviceException" use="literal"/>
+
+               </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="createFaceToFaceConversation">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="reopenCase">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+			   <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+        <!--  Audit Services -->
+
+          <wsdl:operation name="updateAuditOperationStatus">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveAuditableServiceNames">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveAuditableOperationsForService">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+		  <wsdl:operation name="retrieveAuditHeaders">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+    		   <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+          <wsdl:operation name="retrieveAuditDetail">
+
+               <soap:operation soapAction="http://www.lagan.com/wsdl/FLService"/>
+
+               <wsdl:input>
+
+                    <soap:body use="literal"/>
+
+               </wsdl:input>
+
+               <wsdl:output>
+
+				    <soap:body use="literal"/>
+
+			   </wsdl:output>
+
+			   <wsdl:fault name="serviceException">
+
+				    <soap:fault name="serviceException" use="literal"/>
+
+			   </wsdl:fault>
+
+          </wsdl:operation>
+
+     </wsdl:binding>
+
+
+    <!--*********************************************************************************-->
+
+    <!--  WSDL SERVICE  -->
+
+    <!--*********************************************************************************-->
+
+     <wsdl:service name="FLWebService">
+
+          <wsdl:port binding="fls:FLWebBinding" name="FL">
+
+               <soap:address location="http://crmtest:5080/lagan/services/FL"/>
+
+          </wsdl:port>
+
+     </wsdl:service>
+
+</wsdl:definitions>

--- a/spec/wasabi/parser/message_element_spec.rb
+++ b/spec/wasabi/parser/message_element_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Wasabi::Parser do
+  context 'with: savon562.wsdl' do
+    subject do
+      parser = Wasabi::Parser.new Nokogiri::XML(xml)
+      parser.parse
+      parser
+    end
+
+    let(:xml) { fixture(:savon562).read }
+
+    it 'parses the operations' do
+      subject.operations[:write_case_eform_data][:input].should == 'writeCaseEformData'
+    end
+  end
+end


### PR DESCRIPTION
Here's a failing spec for [#562](https://github.com/savonrb/savon/issues/562) which follows up on some regressions that seemed to have been reverted in PR [#39](https://github.com/savonrb/wasabi/pull/39). Hopefully this kicks off a bit of discussion on how best to move forward with the logic behind properly setting the message tag. 

In the case of issue #562, element may not work for setting the message_tag. [This section](https://github.com/savonrb/wasabi/blob/master/lib/wasabi/parser.rb#L273-280) of the parser in particular may need to be refactored a bit to accommodate this WSDL and others like it.

Here's the snippet from the WSDL:

```
<wsdl:message name="writeCaseEformData">
      <wsdl:part element="flt:FLEformFields" name="WriteCaseEform"/>
</wsdl:message>

<wsdl:operation name="writeCaseEformData">
       <wsdl:input message="fls:writeCaseEformData"/>
       <wsdl:output message="fls:writeCaseEformDataResponse"/>
       <wsdl:fault message="fls:serviceException" name="serviceException"/>
</wsdl:operation>
```
