### PR TITLE
Bump Nokogiri version to 1.4.2

### DIFF
--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "httpi",    "~> 2.0"
-  s.add_dependency "nokogiri", ">= 1.4.0"
+  s.add_dependency "nokogiri", ">= 1.4.2"
 
   s.add_development_dependency "rake",  "~> 0.9"
   s.add_development_dependency "rspec", "~> 2.14"


### PR DESCRIPTION
Wasabi uses Nokogiri's element_children method, which wasn't introduced
until 1.4.2.
