### PR TITLE
fix for error in parsing operations with namespaced input elements

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -265,7 +265,6 @@ module Wasabi
           port_message_part = port_element.to_s
           if port_message_part.include?(':')
             message_ns_id, message_type = port_message_part.split(':')
-            message_type = input_element['name']
           else
             message_type = port_message_part['name']
           end

--- a/spec/wasabi/parser/marketo_spec.rb
+++ b/spec/wasabi/parser/marketo_spec.rb
@@ -11,7 +11,7 @@ describe Wasabi::Parser do
     let(:xml) { fixture(:marketo).read }
 
     it 'parses the operations' do
-      expect(subject.operations[:get_lead][:input]).to eq('getLead')
+      expect(subject.operations[:get_lead][:input]).to eq('paramsGetLead')
     end
   end
 end

--- a/spec/wasabi/parser/message_element_spec.rb
+++ b/spec/wasabi/parser/message_element_spec.rb
@@ -11,7 +11,7 @@ describe Wasabi::Parser do
     let(:xml) { fixture(:savon562).read }
 
     it 'parses the operations' do
-      subject.operations[:write_case_eform_data][:input].should == 'writeCaseEformData'
+      subject.operations[:write_case_eform_data][:input].should == 'FLEformFields'
     end
   end
 end


### PR DESCRIPTION
I've noticed a problem with parsing input elements for operations. Whenever the input name is namespaced, parser falls back to the method name. I've verified the solution (and fixes to specs) in SoapUI.
