### PR TITLE
Namespace enhancements

### DIFF
--- a/lib/wasabi/document.rb
+++ b/lib/wasabi/document.rb
@@ -101,11 +101,13 @@ module Wasabi
       @type_namespaces ||= begin
         namespaces = []
 
-        parser.types.each do |type, info|
-          namespaces << [[type], info[:namespace]]
+        parser.types.each do |ns, types|
+          types.each do |type, info|
+            namespaces << [[type], info[:namespace]]
 
-          element_keys(info).each do |field|
-            namespaces << [[type, field], info[:namespace]]
+            element_keys(info).each do |field|
+              namespaces << [[type, field], info[:namespace]]
+            end
           end
         end if document
 
@@ -117,12 +119,14 @@ module Wasabi
       @type_definitions ||= begin
         result = []
 
-        parser.types.each do |type, info|
-          element_keys(info).each do |field|
-            field_type = info[field][:type]
-            tag, namespace = field_type.split(":").reverse
+        parser.types.each do |ns, types|
+          types.each do |type, info|
+            element_keys(info).each do |field|
+              field_type = info[field][:type]
+              tag, namespace = field_type.split(":").reverse
 
-            result << [[type, field], tag] if user_defined(namespace)
+              result << [[type, field], tag] if user_defined(namespace)
+            end
           end
         end if document
 

--- a/spec/fixtures/types_with_same_name_in_separate_namespaces.wsdl
+++ b/spec/fixtures/types_with_same_name_in_separate_namespaces.wsdl
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:s="http://www.w3.org/2001/XMLSchema"
+  xmlns:article="http://example.com/article"
+  xmlns:actions="http://example.com/actions"
+  targetNamespace="http://example.com/actions">
+    <types>
+        <s:schema elementFormDefault="qualified" targetNamespace="http://example.com/actions">
+            <s:element name="Save">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element name="article" type="article:Article"/>
+                        <s:element name="actionHeader" type="actions:Header" />
+                        <s:element name="articleHeader" type="article:Header" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="Header">
+                <s:sequence>
+                    <s:element minOccurs="0" name="ActionHeaderField1" type="s:string"/>
+                    <s:element minOccurs="0" name="Description" type="s:string"/>                    
+                </s:sequence>
+            </s:complexType>
+        </s:schema>
+        <s:schema elementFormDefault="qualified" targetNamespace="http://example.com/article">
+            <s:complexType name="Article">
+                <s:sequence>
+                    <s:element minOccurs="0" name="Author" type="s:string"/>
+                    <s:element minOccurs="0" name="Title" type="s:string"/>
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="Header">
+                <s:sequence>
+                    <s:element minOccurs="0" name="ArticleHeaderField1" type="s:string"/>
+                    <s:element minOccurs="0" name="Description" type="s:string"/>                    
+                </s:sequence>
+            </s:complexType>
+        </s:schema>
+    </types>
+    <message name="SaveSoapIn">
+        <part name="parameters" element="actions:Save"/>
+    </message>
+    <message name="SaveSoapOut">
+        <part name="parameters" element="actions:SaveResponse"/>
+    </message>
+    <portType name="ArticleSoap">
+        <operation name="Save">
+            <input message="actions:SaveSoapIn"/>
+            <output message="actions:SaveSoapOut"/>
+        </operation>
+    </portType>
+    <binding name="ArticleSoap" type="actions:ArticleSoap">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <operation name="Save">
+            <soap:operation soapAction="http://example.com/actions.Save" style="document"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+    <service name="StudyMDL">
+        <port name="StudyMDLSoap" binding="actions:StudyMDLSoap">
+            <soap:address location="http://example.com:1234/soap"/>
+        </port>
+    </service>
+</definitions>

--- a/spec/wasabi/document/inherited_spec.rb
+++ b/spec/wasabi/document/inherited_spec.rb
@@ -17,20 +17,20 @@ describe Wasabi::Document do
     end
 
     it "should position base class attributes before subclass attributes in :order! array" do
-      account = subject.parser.types["Account"]
+      account = subject.parser.types['http://object.api.example.com/']["Account"]
       expect(account[:order!]).to eq(["fieldsToNull", "Id", "Description", "ProcessId", "CreatedDate"])
     end
 
     it "should have each type's hash remember it's base type in :base_type element" do
-      account = subject.parser.types["Account"]
+      account = subject.parser.types['http://object.api.example.com/']["Account"]
       expect(account[:base_type]).to eq("baseObject")
 
-      base_object = subject.parser.types["baseObject"]
+      base_object = subject.parser.types['http://object.api.example.com/']["baseObject"]
       expect(base_object).not_to have_key(:base_type)
     end
 
     it "should have element's hash contain all these attributes (:nillable, :minOccurs, :maxOccurs) in addition to :type" do
-      base_object = subject.parser.types["baseObject"]
+      base_object = subject.parser.types['http://object.api.example.com/']["baseObject"]
       fields_to_null = base_object["fieldsToNull"]
       expect(fields_to_null[:nillable]).to eq("true")
       expect(fields_to_null[:minOccurs]).to eq("0")

--- a/spec/wasabi/parser/multiple_namespaces_spec.rb
+++ b/spec/wasabi/parser/multiple_namespaces_spec.rb
@@ -11,29 +11,34 @@ describe Wasabi::Parser do
 
     let(:xml) { fixture(:multiple_namespaces).read }
 
-    it "lists the types" do
-      expect(subject.types.keys.sort).to eq(["Article", "Save"])
+    it "lists the namespaces" do
+      expect(subject.types.keys.sort).to eq(["http://example.com/actions", "http://example.com/article"])
+    end
+
+    it "lists the types for each namespace" do
+      expect(subject.types['http://example.com/actions'].keys.sort).to eq(["Save"])
+      expect(subject.types['http://example.com/article'].keys.sort).to eq(["Article"]) 
     end
 
     it "records the namespace for each type" do
-      expect(subject.types["Save"][:namespace]).to eq("http://example.com/actions")
+      expect(subject.types["http://example.com/actions"]["Save"][:namespace]).to eq("http://example.com/actions")
     end
 
     it "records the fields under a type" do
-      expect(subject.types["Save"].keys).to match_array(["article", :namespace, :order!])
+      expect(subject.types['http://example.com/actions']["Save"].keys).to match_array(["article", :namespace, :order!])
     end
 
     it "records multiple fields when there are more than one" do
-      expect(subject.types["Article"].keys).to match_array(["Title", "Author", :namespace, :order!])
+      expect(subject.types['http://example.com/article']["Article"].keys).to match_array(["Title", "Author", :namespace, :order!])
     end
 
     it "records the type of a field" do
-      expect(subject.types["Save"]["article"][:type]).to eq("article:Article")
+      expect(subject.types['http://example.com/actions']["Save"]["article"][:type]).to eq("article:Article")
       expect(subject.namespaces["article"]).to eq("http://example.com/article")
     end
 
     it "lists the order of the type elements" do
-      expect(subject.types["Article"][:order!]).to eq(["Author", "Title"])
+      expect(subject.types['http://example.com/article']["Article"][:order!]).to eq(["Author", "Title"])
     end
 
   end

--- a/spec/wasabi/parser/no_namespace_spec.rb
+++ b/spec/wasabi/parser/no_namespace_spec.rb
@@ -12,11 +12,11 @@ describe Wasabi::Parser do
     let(:xml) { fixture(:no_namespace).read }
 
     it "lists the types" do
-      expect(subject.types.keys.sort).to eq(["McContact", "McContactArray", "MpUser", "MpUserArray"])
+      expect(subject.types['urn:ActionWebService'].keys.sort).to eq(["McContact", "McContactArray", "MpUser", "MpUserArray"])
     end
 
     it "ignores xsd:all" do
-      keys =  subject.types["MpUser"].keys
+      keys =  subject.types['urn:ActionWebService']["MpUser"].keys
       expect(keys.size).to eq(2)
 
       expect(keys).to include(:namespace)

--- a/spec/wasabi/parser/no_target_namespace_spec.rb
+++ b/spec/wasabi/parser/no_target_namespace_spec.rb
@@ -29,7 +29,7 @@ describe Wasabi::Parser do
     # but I suppose we should do something reasonable if they do.
 
     it "defaults to the target namespace from xs:definitions" do
-      expect(subject.types["Save"][:namespace]).to eq("http://def.example.com")
+      expect(subject.types["http://def.example.com"]["Save"][:namespace]).to eq("http://def.example.com")
     end
 
   end

--- a/spec/wasabi/parser/symbolic_endpoint_spec.rb
+++ b/spec/wasabi/parser/symbolic_endpoint_spec.rb
@@ -16,7 +16,7 @@ describe Wasabi::Parser do
     end
 
     it "should position base class attributes before subclass attributes in :order! array" do
-      type = subject.types["ROPtsLiesListe"]
+      type = subject.types["http://model.webservices.partner.example.de"]["ROPtsLiesListe"]
       expect(type[:order!]).to eq(["messages", "returncode", "listenteil"])
     end
 

--- a/spec/wasabi/parser/types_with_same_name_in_separate_namespaces_spec.rb
+++ b/spec/wasabi/parser/types_with_same_name_in_separate_namespaces_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Wasabi::Parser do
+  context 'with: types_with_same_name_in_separate_namespaces.wsdl' do
+    subject do
+      parser = Wasabi::Parser.new Nokogiri::XML(xml)
+      parser.parse
+      parser
+    end
+
+    let(:xml) { fixture(:types_with_same_name_in_separate_namespaces).read }
+
+    it 'parses two types in separate namespaces' do
+      expect(subject.types['http://example.com/article'].keys.sort).to eq(['Article', 'Header'])
+      expect(subject.types['http://example.com/actions'].keys.sort).to eq(['Header', 'Save'])
+    end
+    
+    it 'assigns the correct type to the appropriate namespace' do
+      expect(subject.types['http://example.com/article']['Header'][:order!]).to eq(['ArticleHeaderField1', 'Description'])
+      expect(subject.types['http://example.com/article']['Header'][:namespace]).to eq('http://example.com/article')
+      
+      expect(subject.types['http://example.com/actions']['Header'][:order!]).to eq(['ActionHeaderField1', 'Description'])
+      expect(subject.types['http://example.com/actions']['Header'][:namespace]).to eq('http://example.com/actions')      
+    end
+    
+  end
+end


### PR DESCRIPTION
When two complex types with the same name are defined in different namespaces, the parser clobbers one type with the other.  The code provided in this PR aims to segment the declared types by namespace so as to distinguish the distinct types and give the appropriate context within the proper namespace.