### PR TITLE
Original operation name and document style operations

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -1,20 +1,3 @@
-Skip to content
-This repository
-Search
-Pull requests
-Issues
-Gist
- @gokhankuyucak
- Watch 4
-  Star 45
-  Fork 60 savonrb/wasabi
- Code  Issues 10  Pull requests 5  Projects 0  Pulse  Graphs
-Branch: master Find file Copy pathwasabi/lib/wasabi/parser.rb
-6fc97c6  on Mar 3
-@fernandes fernandes Add support for rpc encoded wsdl
-8 contributors @rubiii @tjarratt @keltia @hoverlover @hesenrre @mikeantonelli @jmao @fernandes
-RawBlameHistory     
-333 lines (268 sloc)  11.3 KB
 require 'uri'
 require 'wasabi/core_ext/string'
 
@@ -352,5 +335,3 @@ module Wasabi
     end
   end
 end
-Contact GitHub API Training Shop Blog About
-© 2016 GitHub, Inc. Terms Privacy Security Status Help

--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -142,7 +142,7 @@ module Wasabi
         soap_operation = operation.element_children.find { |node| node.name == 'operation' }
         soap_action = soap_operation['soapAction'] if soap_operation
         soap_document = soap_operation['style'] if soap_operation
-		if soap_action
+        if soap_action
           soap_action = soap_action.to_s
           action = soap_action && !soap_action.empty? ? soap_action : name
 
@@ -153,7 +153,7 @@ module Wasabi
           # Store namespace identifier so this operation can be mapped to the proper namespace.
           @operations[snakecase_name] = { :name =>name, :action => action, :input => input, :output => output, :namespace_identifier => namespace_id}
         elsif soap_document
-		  #if there is no soap_action under operation element maybe operation's style is document and still have input & output
+          #if there is no soap_action under operation element maybe operation's style is document and still have input & output
           namespace_id, output = output_for(operation)
           namespace_id, input = input_for(operation)
           @operations[name.snakecase.to_sym] = { :name =>name, :action => name, :input => input, :output => output, :namespace_identifier => namespace_id}


### PR DESCRIPTION
1. the operation name is converting  from "checkCustomer" to "check_customer" to keep original operation name name element added to operation variable

2. some wsdls don't have soapAction these operations may have a style with name "document". To get input & output names for those type operations, added a new condition 

```
<wsdl:operation name="createGroup">
      <soap:operation style="document"/>
     <wsdl:input name="createGroupRequest"><soap:body use="literal"/></wsdl:input>
     <wsdl:output name="createGroupResponse"><soap:body use="literal"/></wsdl:output>
     <wsdl:fault name="fault"><soap:fault name="fault" use="literal"/></wsdl:fault>
</wsdl:operation>
```
