### PR TITLE
Update parser.rb for WSDL without binding tags

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -133,7 +133,7 @@ module Wasabi
     end
 
     def parse_operations
-      operations = document.xpath('wsdl:definitions/wsdl:binding/wsdl:operation', 'wsdl' => WSDL)
+      operations = document.xpath('wsdl:definitions//wsdl:operation', 'wsdl' => WSDL)
       operations.each do |operation|
         name = operation.attribute('name').to_s
         snakecase_name = Wasabi::CoreExt::String.snakecase(name).to_sym


### PR DESCRIPTION
Update XPATH search in parser.rb for WSDLs without binding tags.  WSDLs without Binding tags surrounding the operations don't work.  This change fixes that.  However, if there were a situation where there were two sets of "operation" elements in a given WSDL with one set outside of the binding tags, this would still get all of those.  I'm not sure that would actually ever happen nor that it would ever actually be undesirable.