### PR TITLE
Check if any messages have been parsed before assuming

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -247,7 +247,6 @@ module Wasabi
       port_type_input_output = port_type_operation &&
         port_type_operation.element_children.find { |node| node.name == input_output }
 
-
       # TODO: Stupid fix for missing support for imports.
       # Sometimes portTypes are actually included in a separate WSDL.
       if port_type_input_output


### PR DESCRIPTION
Fixes an issue I had with a wsdl not having any message definitions in its root wsdl document.
Possibly fixes #49, #54 and #61.