### PR TITLE
CI: Drop Travis sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+language: ruby
 rvm:
   - 2.0.0
   - 2.1.8


### PR DESCRIPTION
Put in the language: ruby marker, for clarity.

This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).