### PR TITLE
gemspec: Depend on addressable, for unescape

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'addressable/uri'
 require 'wasabi/core_ext/string'
 
 module Wasabi
@@ -86,9 +87,8 @@ module Wasabi
     end
 
     def parse_url(url)
-      unescaped_url = URI.unescape(url.to_s)
-      escaped_url   = URI.escape(unescaped_url)
-      URI.parse(escaped_url)
+      unescaped_url = Addressable::URI.unescape(url.to_s)
+      URI(unescaped_url)
     rescue URI::InvalidURIError
     end
 

--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "httpi",    "~> 2.0"
   s.add_dependency "nokogiri", ">= 1.4.2"
+  s.add_dependency "addressable"
 
   s.add_development_dependency "rake",  "~> 0.9"
   s.add_development_dependency "rspec", "~> 2.14"


### PR DESCRIPTION
By using the Addressable gem, this PR **avoids a Ruby deprecation warning** about URI.unencode, without changing behavior.

This PR was created @chaymaebz  and me, based on prior art by @bvicenzo.