### PR TITLE
gemspec: Drop rubyforge reference

### DIFF
--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.required_ruby_version = '>= 1.9.2'
 
-  s.rubyforge_project = s.name
   s.license = 'MIT'
 
   s.add_dependency "httpi",    "~> 2.0"


### PR DESCRIPTION
This PR is intended to remove ruby warning about rubyforge.

Extracted from #75 