### PR TITLE
Rspec style: use named subject

### DIFF
--- a/spec/wasabi/parser/symbolic_endpoint_spec.rb
+++ b/spec/wasabi/parser/symbolic_endpoint_spec.rb
@@ -2,21 +2,18 @@ require "spec_helper"
 
 describe Wasabi::Parser do
   context "with: symbolic_endpoint.wsdl" do
-
-    subject do
-      parser = Wasabi::Parser.new Nokogiri::XML(xml)
-      parser.parse
-      parser
-    end
+    subject(:parser) { described_class.new Nokogiri::XML(xml) }
 
     let(:xml) { fixture(:symbolic_endpoint).read }
 
+    before { parser.parse }
+
     it "allows symbolic endpoints" do
-      expect(subject.endpoint).to be_nil
+      expect(parser.endpoint).to be_nil
     end
 
     it "should position base class attributes before subclass attributes in :order! array" do
-      type = subject.types["ROPtsLiesListe"]
+      type = parser.types["ROPtsLiesListe"]
       expect(type[:order!]).to eq(["messages", "returncode", "listenteil"])
     end
 


### PR DESCRIPTION
This PR purpose is to use named subject to improve readability.

Extracted from #75 

Co-authored-by: Bruno Vicenzo <bvicenzo@users.noreply.github.com>