### PR TITLE
Ruby warning fix: instance variable used before initialize

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -319,14 +319,13 @@ module Wasabi
     end
 
     def sections
-      return @sections if @sections
-
-      sections = {}
-      document.root.element_children.each do |node|
-        (sections[node.name] ||= []) << node
-      end
-
-      @sections = sections
+      @sections ||= begin
+                      sections = {}
+                      document.root.element_children.each do |node|
+                        (sections[node.name] ||= []) << node
+                      end
+                      sections
+                    end
     end
   end
 end


### PR DESCRIPTION
Fixes #62 