### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+require:
+  - rubocop-packaging

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ gem 'simplecov',       :require => false
 gem 'method_profiler', :require => false
 gem 'coveralls',       :require => false
 
+if RUBY_VERSION >= '2.4'
+  gem 'rubocop-packaging', :require => false
+end
+
 platform :rbx do
   gem 'json'
   gem 'racc'

--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake",  "~> 13.0"
   s.add_development_dependency "rspec", "~> 3.7.0"
+  s.add_development_dependency "rubocop-packaging", "~> 0.1.1"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir["lib/**/*", "CHANGELOG.md", "LICENSE", "README.md"]
+  s.test_files    = Dir["spec/**/*"]
   s.require_paths = ["lib"]
 end

--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake",  "~> 13.0"
   s.add_development_dependency "rspec", "~> 3.7.0"
-  s.add_development_dependency "rubocop-packaging", "~> 0.1.1"
 
   s.files         = Dir["lib/**/*", "CHANGELOG.md", "LICENSE", "README.md"]
   s.test_files    = Dir["spec/**/*"]


### PR DESCRIPTION
Hi @olleolleolle,

Thanks for maintaining this so far! :heart: 
As discussed in #68, this PR drops the usage of `git` to list the files and **only** ships the files that are necessary for end-users :rocket: 

Closes: #68

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>