### PR TITLE
Simplify Wasabi::Parser#sections implementation using Enumerable#group_by

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -319,13 +319,7 @@ module Wasabi
     end
 
     def sections
-      @sections ||= begin
-                      sections = {}
-                      document.root.element_children.each do |node|
-                        (sections[node.name] ||= []) << node
-                      end
-                      sections
-                    end
+      @sections ||= document.root.element_children.group_by { |node| node.name }
     end
   end
 end


### PR DESCRIPTION
As suggest [here](https://github.com/savonrb/wasabi/pull/87#discussion_r464631466) it produces the same result and it simpler.