### PR TITLE
Remove Warning: Style/FrozenStringLiteralComment: Missing frozen string literal comment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/lib/wasabi.rb
+++ b/lib/wasabi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "wasabi/version"
 require "wasabi/document"
 require "wasabi/resolver"

--- a/lib/wasabi/core_ext/string.rb
+++ b/lib/wasabi/core_ext/string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Wasabi
   module CoreExt
     module String

--- a/lib/wasabi/document.rb
+++ b/lib/wasabi/document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "nokogiri"
 require "wasabi/resolver"
 require "wasabi/parser"

--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 require 'addressable/uri'
 require 'wasabi/core_ext/string'

--- a/lib/wasabi/resolver.rb
+++ b/lib/wasabi/resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "httpi"
 
 module Wasabi

--- a/lib/wasabi/version.rb
+++ b/lib/wasabi/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Wasabi
   VERSION = '3.6.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler"
 Bundler.require :default, :development
 

--- a/spec/support/adapter.rb
+++ b/spec/support/adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FakeAdapterForTest < HTTPI::Adapter::Base
 
   register :fake_adapter_for_test

--- a/spec/support/fixture.rb
+++ b/spec/support/fixture.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SpecSupport
 
   class Fixture

--- a/spec/support/profiling.rb
+++ b/spec/support/profiling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SpecSupport
 
   def benchmark(&block)

--- a/spec/wasabi/core_ext/string_spec.rb
+++ b/spec/wasabi/core_ext/string_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::CoreExt::String do

--- a/spec/wasabi/document/authentication_spec.rb
+++ b/spec/wasabi/document/authentication_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/economic_spec.rb
+++ b/spec/wasabi/document/economic_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/encoded_endpoint_spec.rb
+++ b/spec/wasabi/document/encoded_endpoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/geotrust_spec.rb
+++ b/spec/wasabi/document/geotrust_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/inherited_spec.rb
+++ b/spec/wasabi/document/inherited_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/multiple_namespaces_spec.rb
+++ b/spec/wasabi/document/multiple_namespaces_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/namespaced_actions_spec.rb
+++ b/spec/wasabi/document/namespaced_actions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/no_namespace_spec.rb
+++ b/spec/wasabi/document/no_namespace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/savon295_spec.rb
+++ b/spec/wasabi/document/savon295_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/soap12_spec.rb
+++ b/spec/wasabi/document/soap12_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document/two_bindings_spec.rb
+++ b/spec/wasabi/document/two_bindings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/document_spec.rb
+++ b/spec/wasabi/document_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Document do

--- a/spec/wasabi/parser/get_servicename_spec.rb
+++ b/spec/wasabi/parser/get_servicename_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/import_port_types_spec.rb
+++ b/spec/wasabi/parser/import_port_types_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/juniper_spec.rb
+++ b/spec/wasabi/parser/juniper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/marketo_spec.rb
+++ b/spec/wasabi/parser/marketo_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/multiple_namespaces_spec.rb
+++ b/spec/wasabi/parser/multiple_namespaces_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/multiple_parts_in_message_spec.rb
+++ b/spec/wasabi/parser/multiple_parts_in_message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/no_message_parts_spec.rb
+++ b/spec/wasabi/parser/no_message_parts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/no_namespace_spec.rb
+++ b/spec/wasabi/parser/no_namespace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/no_target_namespace_spec.rb
+++ b/spec/wasabi/parser/no_target_namespace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/softlayer_spec.rb
+++ b/spec/wasabi/parser/softlayer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/symbolic_endpoint_spec.rb
+++ b/spec/wasabi/parser/symbolic_endpoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Parser do

--- a/spec/wasabi/parser/tradetracker_spec.rb
+++ b/spec/wasabi/parser/tradetracker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Wasabi::Parser do

--- a/spec/wasabi/resolver_spec.rb
+++ b/spec/wasabi/resolver_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi::Resolver do

--- a/spec/wasabi/wasabi_spec.rb
+++ b/spec/wasabi/wasabi_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Wasabi do


### PR DESCRIPTION
Just removing this Rubocop warning.

<img width="1036" alt="Captura de Tela 2020-08-04 às 12 17 43" src="https://user-images.githubusercontent.com/173159/89311543-84acd800-d64c-11ea-885c-d4f9eb38384a.png">
