### PR TITLE
CI: use Bundler cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.7.1
   - 2.6.6


### PR DESCRIPTION
This PR adds Travis caching to try and improve the build speed.

We checked, and Travis's caching seems to work.