### PR TITLE
Configure Coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem 'simplecov',       :require => false
 gem 'method_profiler', :require => false
-gem 'coveralls',       :require => false
+gem 'coveralls', '~> 0.8', :require => false
 
 if RUBY_VERSION >= '2.4'
   gem 'rubocop-packaging', :require => false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,11 +6,7 @@ Bundler.require :default, :development
 unless RUBY_PLATFORM =~ /java/
   require "simplecov"
   require "coveralls"
-
-  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-  SimpleCov.start do
-    add_filter "spec"
-  end
+  Coveralls.wear!
 end
 
 support_files = File.expand_path("spec/support/**/*.rb")


### PR DESCRIPTION
This PR configures Coveralls to report to its website.

## Problem:

The earlier Travis builds were all using a 0.7.3, which seemed to work locally, but when they landed on the website, the website showed 0%. (They were also not starting the reporting right, and were missing a configuration file.)

<details>

<summary>Travis log excerpt</summary>

```
[Coveralls] Submitting with config:
{
  "environment": {
    "pwd": "/home/travis/build/savonrb/wasabi",
    "rails_root": null,
    "simplecov_root": "/home/travis/build/savonrb/wasabi",
    "gem_version": "0.7.2",
    "travis_job_id": "721789725",
    "travis_pull_request": "false"
  },
  "git": {
    "head": {
      "id": "028cf56c25f1e035da2b6c694a9f7b7789fd956d",
      "committer_name": "Olle Jonsson",
      "committer_email": "olle.jonsson@gmail.com",
      "message": "CI: use Bundler cache"
    },
    "branch": "(HEAD detached at 028cf56)",
    "remotes": [
      {
        "name": "origin",
        "url": "https://github.com/savonrb/wasabi.git"
      }
    ]
  },
  "service_job_id": "721789725",
  "service_name": "travis-ci"
}

[Coveralls] Submitting to https://coveralls.io/api/v1
[Coveralls] Job #525.1
[Coveralls] https://coveralls.io/jobs/66943777
Coverage is at 100.0%.
Coverage report sent to Coveralls.
```

</details>

## Result

<img width="1130" alt="bild" src="https://user-images.githubusercontent.com/211/91484183-266cc100-e8a9-11ea-9918-1e7ed16d7392.png">
