### PR TITLE
gemspec: Metadata section points out the CHANGELOG

### DIFF
--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.metadata = {
     "changelog_uri" =>
       "https://github.com/savonrb/wasabi/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/wasabi/#{s.version}",
     "source_code_uri" => "https://github.com/savonrb/wasabi",
     "bug_tracker_uri" => "https://github.com/savonrb/wasabi/issues",
   }

--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -24,4 +24,10 @@ Gem::Specification.new do |s|
   s.files         = Dir["lib/**/*", "CHANGELOG.md", "LICENSE", "README.md"]
   s.test_files    = Dir["spec/**/*"]
   s.require_paths = ["lib"]
+  s.metadata = {
+    "changelog_uri" =>
+      "https://github.com/savonrb/wasabi/blob/master/CHANGELOG.md",
+    "source_code_uri" => "https://github.com/savonrb/wasabi",
+    "bug_tracker_uri" => "https://github.com/savonrb/wasabi/issues",
+  }
 end


### PR DESCRIPTION
This PR adds a [gemspec metadata](https://guides.rubygems.org/specification-reference/#metadata) section: allows the CHANGELOG to be visible from RubyGems.org.

Co-Authored-By: @chaymaeBZ 