### PR TITLE
Fix: Escape URL before converting to URI; catch Addressable::URI::InvalidURIError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - _Your new line here. Mind the style of prefix used in the rest of the document._
+- Fix: Support escaped endpoint urls ([#100](https://github.com/savonrb/wasabi/pull/100))
 
 # 3.6.1 (2020-08-27)
 

--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -90,8 +90,9 @@ module Wasabi
 
     def parse_url(url)
       unescaped_url = Addressable::URI.unescape(url.to_s)
-      URI(unescaped_url)
-    rescue URI::InvalidURIError
+      escaped_url = Addressable::URI.escape(unescaped_url)
+      URI(escaped_url)
+    rescue URI::InvalidURIError, Addressable::URI::InvalidURIError
     end
 
     def parse_service_name

--- a/spec/fixtures/escaped_endpoint.wsdl
+++ b/spec/fixtures/escaped_endpoint.wsdl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:s="http://www.w3.org/2001/XMLSchema"
+  xmlns:actions="http://example.com/actions"
+  targetNamespace="http://example.com/topLevelNamespace">
+    <types>
+        <s:schema elementFormDefault="qualified" targetNamespace="http://example.com/actions">
+            <s:element name="SomeRequest">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element name="status" type="s:string"/>
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+        </s:schema>
+    </types>
+    <message name="SomeInput">
+        <part name="parameters" element="actions:SomeRequest"/>
+    </message>
+    <message name="SomeOutput">
+        <part name="parameters" element="actions:SomeResponse"/>
+    </message>
+    <portType name="ExamplePortType">
+        <operation name="SomeOperation">
+            <input message="actions:SomeInput"/>
+            <output message="actions:SomeOutput"/>
+        </operation>
+    </portType>
+    <binding name="ExampleBinding" type="actions:ExamplePortType">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <operation name="SomeOperation">
+            <soap:operation soapAction="http://example.com/actions.SomeOperation" style="document"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+    <service name="ExampleService">
+        <port name="ExamplePort" binding="actions:ExampleBinding">
+            <soap:address location="http://localhost/soap%20service"/>
+        </port>
+    </service>
+</definitions>

--- a/spec/wasabi/document/escaped_endpoint_spec.rb
+++ b/spec/wasabi/document/escaped_endpoint_spec.rb
@@ -1,0 +1,16 @@
+
+require "spec_helper"
+
+describe Wasabi::Document do
+  context "with: escaped_endpoint.wsdl" do
+
+    subject(:document) { Wasabi::Document.new fixture(:escaped_endpoint).read }
+
+    describe '#endpoint' do
+      it "supports spaces in URIs" do
+        expect(document.endpoint).to eq URI("http://localhost/soap%20service")
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
This allows urls with spaces in, as they were previously re-escaped (in v3.5.0)

We now also catch the Addressable::URI::InvalidURIError, as that might be raised while escaping if URI is invalid