### PR TITLE
Add Ruby 3 to run on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
+  - 3.0.0
   - 2.7.1
   - 2.6.6
   - 2.5.8


### PR DESCRIPTION
Just configuring Travis CI to run tests using the new Ruby version 3.0