### PR TITLE
Update httpi to 3.x

### DIFF
--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency "httpi",    "~> 2.0"
+  s.add_dependency "httpi",    "~> 3.0"
   s.add_dependency "nokogiri", ">= 1.4.2"
   s.add_dependency "addressable"
 


### PR DESCRIPTION
`bundle outdated` shows `httpi` as outdated

```
$ bundle outdated
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies......

Gem     Current  Latest  Requested  Groups
httpi   2.5.0    3.0.1
```