### PR TITLE
Fix input/output for `style="rpc"` operations

### DIFF
--- a/lib/wasabi/parser.rb
+++ b/lib/wasabi/parser.rb
@@ -144,7 +144,7 @@ module Wasabi
         # TODO: check for soap namespace?
         soap_operation = operation.element_children.find { |node| node.name == 'operation' }
         soap_action = soap_operation['soapAction'] if soap_operation
-        soap_document = soap_operation["style"] if soap_operation
+        soap_document = soap_operation['style'] == 'document'  if soap_operation
 
         if soap_action || soap_document
           soap_action = soap_action.to_s
@@ -260,8 +260,13 @@ module Wasabi
         end
 
         message_ns_id, message_type = nil
-        message_ns_id = port_message_ns_id
-        message_type = port_message_type
+
+        soap_operation = operation.element_children.find { |node| node.name == 'operation' }
+
+        if soap_operation.nil? || soap_operation['style'] != 'rpc'
+          message_ns_id = port_message_ns_id
+          message_type = port_message_type
+        end
 
         # When there is a parts attribute in soap:body element, we should use that value
         # to look up the message part from messages array.

--- a/spec/fixtures/rpc_operation.wsdl
+++ b/spec/fixtures/rpc_operation.wsdl
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<definitions
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    name="ExampleService"
+    targetNamespace="http://www.example.com"
+    xmlns:tns="http://www.example.com"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+  <message name="ExampleOperationRequest">
+    <part name="ExampleField" type="xs:string"/>
+  </message>
+  <message name="ExampleOperationResponse">
+    <part name="ExampleField" type="xs:string"/>
+  </message>
+  <portType name="ExamplePortType">
+    <operation name="ExampleOperation">
+      <input message="tns:ExampleOperationRequest"/>
+      <output message="tns:ExampleOperationResponse"/>
+    </operation>
+  </portType>
+  <binding name="ExampleBinding" type="tns:ExamplePortType">
+    <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="ExampleOperation">
+      <soap:operation soapAction="urn:ExampleInterface-ExamplePortType#ExampleOperation" style="rpc"/>
+      <input>
+        <soap:body use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:ExampleInterface-ExamplePortType"/>
+      </input>
+      <output>
+        <soap:body use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:ExampleInterface-ExamplePortType"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="ExampleService">
+    <port name="ExamplePort" binding="tns:ExampleBinding">
+      <soap:address location="http://example.com/ExampleService.dll/soap/ExamplePortType"/>
+    </port>
+  </service>
+</definitions>

--- a/spec/wasabi/document/rpc_spec.rb
+++ b/spec/wasabi/document/rpc_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Wasabi::Document do
+  context "with: rpc_operation.wsdl" do
+    subject { Wasabi::Document.new(fixture(:rpc_operation).read) }
+
+    describe "#operations" do
+      subject { super().operations }
+
+      it do
+        should include(
+          {
+            example_operation: {
+              action: "urn:ExampleInterface-ExamplePortType#ExampleOperation",
+              input: "ExampleOperation",
+              output: "ExampleOperation",
+              namespace_identifier: "tns"
+            }
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #118

I provided an example WSDL (`spec/fixtures/rpc.xml`) based on a real one from a service that I use.

Until version 3.8, the gem was generating the following operation:

```ruby
{
  example_operation: {
    action: "urn:ExampleInterface-ExamplePortType#ExampleOperation",
    input: "ExampleOperation",
    output: "ExampleOperation",
    namespace_identifier: "tns"
  }
}
```

As for 4.0, it has changed to:

```ruby
{
  example_operation: {
    action: "urn:ExampleInterface-ExamplePortType#ExampleOperation",
    input: "ExampleOperationRequest",
    output: "ExampleOperationResponse",
    namespace_identifier: "tns"
  }
}
```

This resulted in a different body when using it in savon:

```diff
<soap:Body>
-  <ExampleOperation>
+  <ExampleOperationRequest>
    ...
-  </ExampleOperation>
+  </ExampleOperationRequest>
</soap:Body>
```

I disabled that behaviour for `style="rpc"` operations, but I'm not sure if this is the right solution.