### PR TITLE
Relax faraday version restriction

### DIFF
--- a/wasabi.gemspec
+++ b/wasabi.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency "faraday",    "~> 2.8"
+  s.add_dependency "faraday", ">=1.9", "<3"
   s.add_dependency "nokogiri", ">= 1.13.9"
   s.add_dependency "addressable"
 


### PR DESCRIPTION
This PR relaxes the version restriction for the faraday gem to allow it to be used with versions of faraday below version 2.0.  This is related to the following issue identified with the httpi gem: https://github.com/savonrb/httpi/issues/251.  See comments on that issue for additional context.