### PR TITLE
Enhance namespace extraction with comprehensive type definition API and external schema support

### DIFF
--- a/spec/fixtures/external_schemas/address_type.xsd
+++ b/spec/fixtures/external_schemas/address_type.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://example.com/address"
+  xmlns:tns="http://example.com/address">
+  <xs:complexType name="AddressType">
+    <xs:sequence>
+      <xs:element name="street" type="xs:string" />
+      <xs:element name="city" type="xs:string" />
+      <xs:element name="country" type="xs:string" />
+      <xs:element name="zipCode" type="xs:string" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/spec/fixtures/external_schemas/user_type.xsd
+++ b/spec/fixtures/external_schemas/user_type.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://example.com/user"
+  xmlns:tns="http://example.com/user">
+  <xs:complexType name="UserType">
+    <xs:sequence>
+      <xs:element name="username" type="xs:string" />
+      <xs:element name="email" type="xs:string" />
+      <xs:element name="age" type="xs:int" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/spec/fixtures/wsdl_with_external_schemas.xml
+++ b/spec/fixtures/wsdl_with_external_schemas.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/service"
+             xmlns:addr="http://example.com/address"
+             xmlns:user="http://example.com/user"
+             targetNamespace="http://example.com/service">
+  
+  <types>
+    <xs:schema targetNamespace="http://example.com/address">
+      <xs:include schemaLocation="external_schemas/address_type.xsd"/>
+    </xs:schema>
+    
+    <xs:schema targetNamespace="http://example.com/user">
+      <xs:import namespace="http://example.com/user" 
+                 schemaLocation="external_schemas/user_type.xsd"/>
+    </xs:schema>
+    
+    <xs:schema targetNamespace="http://example.com/service">
+      <xs:import namespace="http://example.com/address"/>
+      <xs:import namespace="http://example.com/user"/>
+      
+      <xs:element name="CreateUserRequest">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="user" type="user:UserType"/>
+            <xs:element name="address" type="addr:AddressType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      
+      <xs:element name="CreateUserResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="userId" type="xs:string"/>
+            <xs:element name="success" type="xs:boolean"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  
+  <message name="CreateUserRequestMessage">
+    <part name="parameters" element="tns:CreateUserRequest"/>
+  </message>
+  
+  <message name="CreateUserResponseMessage">
+    <part name="parameters" element="tns:CreateUserResponse"/>
+  </message>
+  
+  <portType name="UserServicePortType">
+    <operation name="CreateUser">
+      <input message="tns:CreateUserRequestMessage"/>
+      <output message="tns:CreateUserResponseMessage"/>
+    </operation>
+  </portType>
+  
+  <binding name="UserServiceBinding" type="tns:UserServicePortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="CreateUser">
+      <soap:operation soapAction="http://example.com/service/CreateUser"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  
+  <service name="UserService">
+    <port name="UserServicePort" binding="tns:UserServiceBinding">
+      <soap:address location="http://example.com/user-service"/>
+    </port>
+  </service>
+</definitions>

--- a/spec/wasabi/document/type_definitions_spec.rb
+++ b/spec/wasabi/document/type_definitions_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Wasabi::Document do
+  context "type definitions" do
+    subject { Wasabi::Document.new fixture(:multiple_namespaces).read }
+
+    describe '#type_definition' do
+      it "returns type information with fields" do
+        article_type = subject.type_definition("Article")
+        
+        expect(article_type[:name]).to eq("Article")
+        expect(article_type[:namespace]).to eq("http://example.com/article")
+        expect(article_type[:fields]["Author"][:type]).to eq("s:string")
+        expect(article_type[:fields]["Title"][:type]).to eq("s:string")
+        expect(article_type[:order]).to eq(["Author", "Title"])
+      end
+
+      it "returns nil for non-existent types" do
+        expect(subject.type_definition("NonExistentType")).to be_nil
+      end
+    end
+
+    describe '#operation_input_type' do
+      it "returns input type for operations" do
+        input_type = subject.operation_input_type(:save)
+        
+        expect(input_type[:name]).to eq("Save")
+        expect(input_type[:namespace]).to eq("http://example.com/actions")
+        expect(input_type[:fields]["article"][:type]).to eq("article:Article")
+      end
+    end
+
+    describe '#operation_output_type' do
+      it "returns output type for operations" do
+        output_type = subject.operation_output_type(:save)
+        
+        if output_type
+          expect(output_type[:name]).to match(/Save/)
+        end
+      end
+    end
+  end
+end

--- a/spec/wasabi/document/type_resolution_spec.rb
+++ b/spec/wasabi/document/type_resolution_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Wasabi::Document do
+  context "type resolution" do
+    describe 'qualified type names' do
+      let(:wsdl) do
+        %Q{<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:s="http://www.w3.org/2001/XMLSchema"
+  xmlns:ns1="http://example.com/ns1"
+  xmlns:ns2="http://example.com/ns2"
+  targetNamespace="http://example.com/test">
+  <types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://example.com/ns1">
+      <s:complexType name="Address">
+        <s:sequence>
+          <s:element name="street" type="s:string"/>
+        </s:sequence>
+      </s:complexType>
+    </s:schema>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://example.com/ns2">
+      <s:complexType name="Address">
+        <s:sequence>
+          <s:element name="country" type="s:string"/>
+        </s:sequence>
+      </s:complexType>
+    </s:schema>
+  </types>
+</definitions>}
+      end
+
+      subject { Wasabi::Document.new wsdl }
+
+      it "resolves same-named types in different namespaces" do
+        ns1_type = subject.type_definition("ns1:Address")
+        ns2_type = subject.type_definition("ns2:Address")
+        
+        expect(ns1_type[:fields]).to have_key("street")
+        expect(ns2_type[:fields]).to have_key("country")
+      end
+    end
+
+    describe 'Type suffix pattern' do
+      let(:wsdl) do
+        %Q{<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:s="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://example.com/test">
+  <types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://example.com/test">
+      <s:complexType name="UserType">
+        <s:sequence>
+          <s:element name="username" type="s:string"/>
+        </s:sequence>
+      </s:complexType>
+    </s:schema>
+  </types>
+</definitions>}
+      end
+
+      subject { Wasabi::Document.new wsdl }
+
+      it "finds UserType when looking for User" do
+        user_type = subject.type_definition("User")
+        expect(user_type[:fields]).to have_key("username")
+      end
+    end
+  end
+end

--- a/spec/wasabi/parser/external_schema_spec.rb
+++ b/spec/wasabi/parser/external_schema_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Wasabi::Parser do
+  context "external schemas" do
+    let(:wsdl_path) { File.expand_path("../../fixtures/wsdl_with_external_schemas.xml", __dir__) }
+    
+    describe 'loading WSDL with external schemas' do
+      context "when loading from file path" do
+        subject { Wasabi::Document.new(wsdl_path) }
+        
+        it "loads types from included XSD files" do
+          # AddressType is loaded via xs:include
+          address_type = subject.type_definition("AddressType")
+          expect(address_type).to be_a(Hash)
+          expect(address_type[:fields]).to have_key("street")
+          expect(address_type[:fields]).to have_key("city")
+        end
+        
+        it "loads types from imported XSD files" do
+          # UserType is loaded via xs:import
+          user_type = subject.type_definition("UserType")
+          expect(user_type).to be_a(Hash)
+          expect(user_type[:fields]).to have_key("username")
+          expect(user_type[:fields]).to have_key("email")
+        end
+        
+        it "resolves types used in operations" do
+          # The create_user operation uses both external types
+          input_type = subject.operation_input_type(:create_user)
+          expect(input_type).to be_a(Hash)
+          expect(input_type[:name]).to eq("CreateUserRequest")
+        end
+      end
+      
+      
+      context "when loading from string without document option" do
+        subject { Wasabi::Document.new(File.read(wsdl_path)) }
+        
+        it "cannot load external schemas without base path" do
+          # Without a base path, external schemas can't be resolved
+          address_type = subject.type_definition("AddressType")
+          expect(address_type).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR potentially improves Wasabi's handling of WSDL documents that use external schemas and multiple namespaces, adding support for extracting detailed type information needed by SOAP clients like Savon.

## Motivation
I ran into issues with enterprise WSDL documents where Savon needed more type information to construct requests correctly. This PR can address those gaps while keeping backward compatibility.

### Disclosure
I had Claude do a bit of the heavy lifting here - but I've tested this implementation towards some of the use cases I've faced.

Let me know if you need any changes or have questions about the approach.